### PR TITLE
Fix incorrect use of literal block syntax

### DIFF
--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -3441,13 +3441,13 @@ cdef class Gen(Gen_base):
         >>> e.omega()
         [1.26920930427955, 0.634604652139777 - 1.45881661693850*I]
 
-        The precision is determined by the ``ellinit`` call::
+        The precision is determined by the ``ellinit`` call:
 
         >>> e = pari([0, -1, 1, -10, -20]).ellinit(precision=256)
         >>> e.omega().bitprecision()
         256
 
-        This also works over quadratic imaginary number fields::
+        This also works over quadratic imaginary number fields:
 
         >>> e = pari.ellinit([0, -1, 1, -10, -20], "nfinit(y^2 - 2)")
         >>> if pari.version() >= (2, 10, 1):


### PR DESCRIPTION
Fixes these warnings when building documentation:
```
docstring of cypari2.gen.Gen.omega:16: WARNING: Inconsistent literal block quoting.
docstring of cypari2.gen.Gen.omega:22: WARNING: Inconsistent literal block quoting.
```
The double colon introduces a literal block, which must be indented.  There is no need for that here, though.  Just removing the extra colons produces output that looks right.