### PR TITLE
convert.pyx: fix build with Python 3.11

### DIFF
--- a/cypari2/convert.pyx
+++ b/cypari2/convert.pyx
@@ -59,8 +59,7 @@ cdef extern from *:
     ctypedef struct PyLongObject:
         digit* ob_digit
 
-    Py_ssize_t* Py_SIZE_PTR "&Py_SIZE"(object)
-
+    void __Pyx_SET_SIZE(object, Py_ssize_t)
 
 ########################################################################
 # Conversion PARI -> Python
@@ -450,13 +449,10 @@ cdef PyLong_FromINT(GEN g):
         if d:
             sizedigits_final = i+1
 
-    # Set correct size (use a pointer to hack around Cython's
-    # non-support for lvalues).
-    cdef Py_ssize_t* sizeptr = Py_SIZE_PTR(x)
     if signe(g) > 0:
-        sizeptr[0] = sizedigits_final
+        __Pyx_SET_SIZE(x, sizedigits_final);
     else:
-        sizeptr[0] = -sizedigits_final
+        __Pyx_SET_SIZE(x, -sizedigits_final);
 
     return x
 


### PR DESCRIPTION
From Python 3.9, Python provides Py_SET_SIZE to set size of Object. From Python 3.11, Py_SIZE is no longer a macro, it's converted to a function, thus its return value is now prvalue.

Cython provides a function to set size from 0.29.20 [1].

Let's use that instead.

[1]: https://github.com/cython/cython/pull/3639/