### PR TITLE
fix for python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+                python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11.0-rc.2']
                 pari-version: ['pari-2.9.4', 'pari-2.9.5', 'pari-2.11.0', 'pari-2.11.0', 'pari-2.11.2', 'pari-2.11.3', 'pari-2.11.4', 'pari-2.13.0', 'snapshot']
         env:
           LC_ALL: C

--- a/cypari2/Py_SET_SIZE.h
+++ b/cypari2/Py_SET_SIZE.h
@@ -1,0 +1,8 @@
+#include "Python.h"
+
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9)
+// The function Py_SET_SIZE is defined starting with python 3.9.
+void Py_SET_SIZE(PyVarObject *o, Py_ssize_t size){
+    Py_SIZE(o) = size;
+}
+#endif

--- a/cypari2/convert.pxd
+++ b/cypari2/convert.pxd
@@ -4,6 +4,7 @@ from .gen cimport Gen
 from cpython.int cimport PyInt_AS_LONG
 from cpython.float cimport PyFloat_AS_DOUBLE
 from cpython.complex cimport PyComplex_RealAsDouble, PyComplex_ImagAsDouble
+from cpython.longintrepr cimport py_long
 
 
 # Conversion PARI -> Python
@@ -59,7 +60,7 @@ cdef inline GEN doubles_to_COMPLEX(double re, double im):
 cdef inline GEN PyInt_AS_GEN(x):
     return stoi(PyInt_AS_LONG(x))
 
-cdef GEN PyLong_AS_GEN(x)
+cdef GEN PyLong_AS_GEN(py_long x)
 
 cdef inline GEN PyFloat_AS_GEN(x):
     return double_to_REAL(PyFloat_AS_DOUBLE(x))

--- a/cypari2/convert.pyx
+++ b/cypari2/convert.pyx
@@ -59,7 +59,7 @@ cdef extern from *:
     ctypedef struct PyLongObject:
         digit* ob_digit
 
-    Py_ssize_t* Py_SIZE_PTR "&Py_SIZE"(object)
+    void __Pyx_SET_SIZE(object, Py_ssize_t)
 
 
 ########################################################################
@@ -450,13 +450,11 @@ cdef PyLong_FromINT(GEN g):
         if d:
             sizedigits_final = i+1
 
-    # Set correct size (use a pointer to hack around Cython's
-    # non-support for lvalues).
-    cdef Py_ssize_t* sizeptr = Py_SIZE_PTR(x)
+    # Set correct size
     if signe(g) > 0:
-        sizeptr[0] = sizedigits_final
+        __Pyx_SET_SIZE(x, sizedigits_final)
     else:
-        sizeptr[0] = -sizedigits_final
+        __Pyx_SET_SIZE(x, -sizedigits_final)
 
     return x
 

--- a/cypari2/convert.pyx
+++ b/cypari2/convert.pyx
@@ -59,7 +59,8 @@ cdef extern from *:
     ctypedef struct PyLongObject:
         digit* ob_digit
 
-    void __Pyx_SET_SIZE(object, Py_ssize_t)
+cdef extern from "Py_SET_SIZE.h":
+    void Py_SET_SIZE(py_long o, Py_ssize_t size)
 
 
 ########################################################################
@@ -422,8 +423,8 @@ cdef PyLong_FromINT(GEN g):
     # Actual correct computed size
     cdef Py_ssize_t sizedigits_final = 0
 
-    x = _PyLong_New(sizedigits)
-    cdef digit* D = (<PyLongObject*>x).ob_digit
+    cdef py_long x = _PyLong_New(sizedigits)
+    cdef digit* D = x.ob_digit
 
     cdef digit d
     cdef ulong w
@@ -452,9 +453,9 @@ cdef PyLong_FromINT(GEN g):
 
     # Set correct size
     if signe(g) > 0:
-        __Pyx_SET_SIZE(x, sizedigits_final)
+        Py_SET_SIZE(x, sizedigits_final)
     else:
-        __Pyx_SET_SIZE(x, -sizedigits_final)
+        Py_SET_SIZE(x, -sizedigits_final)
 
     return x
 
@@ -463,8 +464,8 @@ cdef PyLong_FromINT(GEN g):
 # Conversion Python -> PARI
 ########################################################################
 
-cdef GEN PyLong_AS_GEN(x):
-    cdef const digit* D = (<PyLongObject*>x).ob_digit
+cdef GEN PyLong_AS_GEN(py_long x):
+    cdef const digit* D = x.ob_digit
 
     # Size of the input
     cdef size_t sizedigits

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open('VERSION') as f:
 setup(
     name='cypari2',
     version=VERSION,
-    setup_requires=['Cython>=0.28'],
+    setup_requires=['Cython>=0.29'],
     install_requires=['cysignals>=1.7'],
     description="A Python interface to the number theory library PARI/GP",
     long_description=README,


### PR DESCRIPTION
This shall fix #114.

It is supposed to replace:
- #115, as it also provided the CI tests for python 3.11
- #103 (which is included, but fixed in terms of depending only on cython 0.29).