### PR TITLE
using cython-lint to find some issues

### DIFF
--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -59,7 +59,7 @@ from __future__ import absolute_import, division, print_function
 
 cimport cython
 
-from cpython.object cimport (Py_EQ, Py_NE, Py_LE, Py_GE, Py_LT, Py_GT,
+from cpython.object cimport (Py_EQ, Py_NE, Py_LE, Py_GE, Py_LT,
         PyTypeObject)
 
 from cysignals.memory cimport sig_free, check_malloc
@@ -69,8 +69,7 @@ from .types cimport *
 from .string_utils cimport to_string, to_bytes
 from .paripriv cimport *
 from .convert cimport PyObject_AsGEN, gen_to_integer
-from .pari_instance cimport (prec_bits_to_words, prec_words_to_bits,
-                             default_bitprec, get_var)
+from .pari_instance cimport (prec_bits_to_words, get_var)
 from .stack cimport (new_gen, new_gens2, new_gen_noclear,
                      clone_gen, clear_stack, reset_avma,
                      remove_from_pari_stack, move_gens_to_heap)
@@ -871,8 +870,8 @@ cdef class Gen(Gen_base):
         return [r1, r2]
 
     def nf_get_zk(self):
-        """
-        Returns a vector with a `\ZZ`-basis for the ring of integers of
+        r"""
+        Return a vector with a `\ZZ`-basis for the ring of integers of
         this number field. The first element is always `1`.
 
         INPUT:
@@ -1074,8 +1073,8 @@ cdef class Gen(Gen_base):
         return new_gen(idealmoddivisor(self.g, ideal.g))
 
     def pr_get_p(self):
-        """
-        Returns the prime of `\ZZ` lying below this prime ideal.
+        r"""
+        Return the prime of `\ZZ` lying below this prime ideal.
 
         NOTE: ``self`` must be a PARI prime ideal (as returned by
         ``idealprimedec`` for example).
@@ -1096,8 +1095,8 @@ cdef class Gen(Gen_base):
         return clone_gen(pr_get_p(self.g))
 
     def pr_get_e(self):
-        """
-        Returns the ramification index (over `\QQ`) of this prime ideal.
+        r"""
+        Return the ramification index (over `\QQ`) of this prime ideal.
 
         NOTE: ``self`` must be a PARI prime ideal (as returned by
         ``idealprimedec`` for example).
@@ -1123,8 +1122,8 @@ cdef class Gen(Gen_base):
         return e
 
     def pr_get_f(self):
-        """
-        Returns the residue class degree (over `\QQ`) of this prime ideal.
+        r"""
+        Return the residue class degree (over `\QQ`) of this prime ideal.
 
         NOTE: ``self`` must be a PARI prime ideal (as returned by
         ``idealprimedec`` for example).
@@ -1515,7 +1514,7 @@ cdef class Gen(Gen_base):
         >>> type(v[0])
         <... 'cypari2.gen.Gen'>
         """
-        cdef Py_ssize_t i, j, step
+        cdef Py_ssize_t i, j
         cdef Gen x = objtogen(y)
 
         if isinstance(n, tuple):
@@ -1925,7 +1924,6 @@ cdef class Gen(Gen_base):
         """
         # TODO: deprecate
         cdef long n
-        cdef Gen t
 
         if typ(self.g) != t_VEC and typ(self.g) != t_COL:
             raise TypeError("Object (=%s) must be of type t_VEC or t_COL." % self)
@@ -2730,7 +2728,6 @@ cdef class Gen(Gen_base):
         >>> pari('(2.4*x^2 - 1.7)/x').truncate()
         2.40000000000000*x
         """
-        cdef int n
         cdef long e
         cdef Gen y
         sig_on()
@@ -3142,7 +3139,6 @@ cdef class Gen(Gen_base):
         """
         cdef GEN G
         cdef long t
-        cdef Gen g
         sig_on()
         if find_root:
             t = itos(gissquareall(x.g, &G))
@@ -3445,7 +3441,7 @@ cdef class Gen(Gen_base):
         return new_gens2(x, y)
 
     def elltors(self):
-        """
+        r"""
         Return information about the torsion subgroup of the given
         elliptic curve.
 
@@ -3454,7 +3450,6 @@ cdef class Gen(Gen_base):
         -  ``e`` - elliptic curve over `\QQ`
 
         OUTPUT:
-
 
         -  ``gen`` - the order of the torsion subgroup, a.k.a.
            the number of points of finite order
@@ -3465,7 +3460,6 @@ cdef class Gen(Gen_base):
 
         -  ``gen`` - vector giving points on e generating these
            cyclic groups
-
 
         Examples:
 
@@ -3692,7 +3686,7 @@ cdef class Gen(Gen_base):
         return v
 
     def nfbasis(self, long flag=0, fa=None):
-        """
+        r"""
         Integral basis of the field `\QQ[a]`, where ``a`` is a root of
         the polynomial x.
 
@@ -4157,7 +4151,7 @@ cdef class Gen(Gen_base):
         3
         """
         if typ(self.g) != t_CLOSURE:
-            raise TypeError(f"arity() requires a t_CLOSURE")
+            raise TypeError("arity() requires a t_CLOSURE")
         return closure_arity(self.g)
 
     def factorpadic(self, p, long r=20):

--- a/cypari2/handle_error.pyx
+++ b/cypari2/handle_error.pyx
@@ -23,8 +23,6 @@ AUTHORS:
 
 from __future__ import absolute_import, division, print_function
 
-from cpython cimport PyErr_Occurred
-
 from cysignals.signals cimport sig_block, sig_unblock, sig_error
 
 from .paridecl cimport *
@@ -99,7 +97,7 @@ class PariError(RuntimeError):
         >>> PariError(11)
         PariError(11)
         """
-        return "PariError(%d)"%self.errnum()
+        return "PariError(%d)" % self.errnum()
 
     def __str__(self):
         r"""

--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -296,6 +296,7 @@ from .closure cimport _pari_init_closure
 # when no explicit precision is given and the inputs are exact.
 cdef long prec = prec_bits_to_words(53)
 
+
 #################################################################
 # conversions between various real precision models
 #################################################################
@@ -1182,11 +1183,10 @@ cdef class Pari(Pari_auto):
         return new_gen(mpfact(n))
 
     def polsubcyclo(self, long n, long d, v=None):
-        """
+        r"""
         polsubcyclo(n, d, v=x): return the pari list of polynomial(s)
         defining the sub-abelian extensions of degree `d` of the
-        cyclotomic field `\QQ(\zeta_n)`, where `d`
-        divides `\phi(n)`.
+        cyclotomic field `\QQ(\zeta_n)`, where `d` divides `\phi(n)`.
 
         Examples::
 
@@ -1265,8 +1265,8 @@ cdef class Pari(Pari_auto):
         v = self._empty_vector(n)
         if entries is not None:
             if len(entries) != n:
-                raise IndexError("length of entries (=%s) must equal n (=%s)"%\
-                      (len(entries), n))
+                raise IndexError(f"length of entries (={len(entries)}) "
+                                 f"must equal n (={n})")
             for i, x in enumerate(entries):
                 v[i] = x
         return v
@@ -1296,7 +1296,7 @@ cdef class Pari(Pari_auto):
         A = new_gen(zeromatcopy(m,n))
         if entries is not None:
             if len(entries) != m * n:
-                raise IndexError("len of entries (=%s) must be %s*%s=%s"%(len(entries),m,n,m*n))
+                raise IndexError("len of entries (=%s) must be %s*%s=%s" % (len(entries), m, n, m*n))
             k = 0
             for i in range(m):
                 for j in range(n):
@@ -1308,7 +1308,7 @@ cdef class Pari(Pari_auto):
         return A
 
     def genus2red(self, P, p=None):
-        """
+        r"""
         Let `P` be a polynomial with integer coefficients.
         Determines the reduction of the (proper, smooth) genus 2
         curve `C/\QQ`, defined by the hyperelliptic equation `y^2 = P`.
@@ -1318,7 +1318,7 @@ cdef class Pari(Pari_auto):
 
         If the second argument `p` is specified, it must be a prime.
         Then only the local information at `p` is computed and returned.
-        
+
         Examples:
 
         >>> import cypari2

--- a/cypari2/paridecl.pxd
+++ b/cypari2/paridecl.pxd
@@ -1024,7 +1024,6 @@ cdef extern from *:     # PARI headers already included by types.pxd
     long    poliscyclo(GEN f)
     long    poliscycloprod(GEN f)
 
-
     # RgV.c
 
     GEN     Rg_RgC_sub(GEN a, GEN x)
@@ -3171,7 +3170,6 @@ cdef extern from *:     # PARI headers already included by types.pxd
     long    z_pval(long n, GEN p)
     long    z_pvalrem(long n, GEN p, long *py)
 
-
     # gen3.c
 
     GEN     padic_to_Q(GEN x)
@@ -3526,7 +3524,7 @@ cdef extern from *:     # PARI headers already included by types.pxd
     void    shiftaddress_canon(GEN x, long dec)
     long    timer()
     long    timer2()
-    void    traverseheap( void(*f)(GEN, void *), void *data )
+    void    traverseheap(void(*f)(GEN, void *), void *data)
 
     # intnum.c
 

--- a/cypari2/stack.pyx
+++ b/cypari2/stack.pyx
@@ -22,7 +22,6 @@ from cpython.exc cimport PyErr_SetString
 
 from cysignals.signals cimport (sig_on, sig_off, sig_block, sig_unblock,
                                 sig_error)
-from cysignals.memory cimport check_malloc, sig_free
 
 from .gen cimport Gen, Gen_new
 from .paridecl cimport (avma, pari_mainstack, gnil, gcopy,

--- a/cypari2/types.pxd
+++ b/cypari2/types.pxd
@@ -52,9 +52,9 @@ cdef extern from "pari/pari.h":
         t_INFINITY
 
     int BITS_IN_LONG
-    long DEFAULTPREC       #  64 bits precision
-    long MEDDEFAULTPREC    # 128 bits precision
-    long BIGDEFAULTPREC    # 192 bits precision
+    long DEFAULTPREC       # 64 bits precision
+    long MEDDEFAULTPREC   # 128 bits precision
+    long BIGDEFAULTPREC   # 192 bits precision
 
     ulong CLONEBIT
 


### PR DESCRIPTION
I used 
`
cython-lint --ignore=E501,E261,E222,E265,E266,E127,E128,E231,E741 cypari2/
`
to find some minor issues (unused imports, etc) and fixed some of them.