### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11', '3.12']
                 pari-version: ['pari-2.11.4', 'pari-2.13.0', 'pari-2.15.4']
         env:
           LC_ALL: C

--- a/autogen/paths.py
+++ b/autogen/paths.py
@@ -15,12 +15,13 @@ Find out installation paths of PARI/GP
 from __future__ import absolute_import, unicode_literals
 
 import os
+import shutil
+
 from glob import glob
-from distutils.spawn import find_executable
 
 
-# find_executable() returns None if nothing was found
-gppath = find_executable("gp")
+gppath = shutil.which("gp")
+
 if gppath is None:
     # This almost certainly won't work, but we need to put something here
     prefix = "."

--- a/cypari2/Py_SET_SIZE.h
+++ b/cypari2/Py_SET_SIZE.h
@@ -1,8 +1,0 @@
-#include "Python.h"
-
-#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9)
-// The function Py_SET_SIZE is defined starting with python 3.9.
-void Py_SET_SIZE(PyVarObject *o, Py_ssize_t size){
-    Py_SIZE(o) = size;
-}
-#endif

--- a/cypari2/pycore_long.h
+++ b/cypari2/pycore_long.h
@@ -1,0 +1,98 @@
+#include "Python.h"
+#include <stdbool.h>
+
+#if PY_VERSION_HEX >= 0x030C00A5
+#define ob_digit(o)  (((PyLongObject*)o)->long_value.ob_digit)
+#else
+#define ob_digit(o)  (((PyLongObject*)o)->ob_digit)
+#endif
+
+#if PY_VERSION_HEX >= 0x030C00A7
+// taken from cpython:Include/internal/pycore_long.h @ 3.12
+
+/* Long value tag bits:
+ * 0-1: Sign bits value = (1-sign), ie. negative=2, positive=0, zero=1.
+ * 2: Reserved for immortality bit
+ * 3+ Unsigned digit count
+ */
+#define SIGN_MASK 3
+#define SIGN_ZERO 1
+#define SIGN_NEGATIVE 2
+#define NON_SIZE_BITS 3
+
+static inline bool
+_PyLong_IsZero(const PyLongObject *op)
+{
+    return (op->long_value.lv_tag & SIGN_MASK) == SIGN_ZERO;
+}
+
+static inline bool
+_PyLong_IsNegative(const PyLongObject *op)
+{
+    return (op->long_value.lv_tag & SIGN_MASK) == SIGN_NEGATIVE;
+}
+
+static inline bool
+_PyLong_IsPositive(const PyLongObject *op)
+{
+    return (op->long_value.lv_tag & SIGN_MASK) == 0;
+}
+
+static inline Py_ssize_t
+_PyLong_DigitCount(const PyLongObject *op)
+{
+    assert(PyLong_Check(op));
+    return op->long_value.lv_tag >> NON_SIZE_BITS;
+}
+
+#define TAG_FROM_SIGN_AND_SIZE(sign, size) ((1 - (sign)) | ((size) << NON_SIZE_BITS))
+
+static inline void
+_PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
+{
+    assert(size >= 0);
+    assert(-1 <= sign && sign <= 1);
+    assert(sign != 0 || size == 0);
+    op->long_value.lv_tag = TAG_FROM_SIGN_AND_SIZE(sign, (size_t)size);
+}
+
+#else
+// fallback for < 3.12
+
+static inline bool
+_PyLong_IsZero(const PyLongObject *op)
+{
+    return Py_SIZE(op) == 0;
+}
+
+static inline bool
+_PyLong_IsNegative(const PyLongObject *op)
+{
+    return Py_SIZE(op) < 0;
+}
+
+static inline bool
+_PyLong_IsPositive(const PyLongObject *op)
+{
+    return Py_SIZE(op) > 0;
+}
+
+static inline Py_ssize_t
+_PyLong_DigitCount(const PyLongObject *op)
+{
+    Py_ssize_t size = Py_SIZE(op);
+    return size < 0 ? -size : size;
+}
+
+static inline void
+_PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
+{
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9)
+// The function Py_SET_SIZE is defined starting with python 3.9.
+    Py_SIZE(o) = size;
+#else
+    Py_SET_SIZE(op, sign < 0 ? -size : size);
+#endif
+}
+
+#endif

--- a/cypari2/pycore_long.pxd
+++ b/cypari2/pycore_long.pxd
@@ -1,0 +1,9 @@
+from cpython.longintrepr cimport py_long, digit
+
+cdef extern from "pycore_long.h":
+    digit* ob_digit(py_long o)
+    bint _PyLong_IsZero(py_long o)
+    bint _PyLong_IsNegative(py_long o)
+    bint _PyLong_IsPositive(py_long o)
+    Py_ssize_t _PyLong_DigitCount(py_long o)
+    void _PyLong_SetSignAndDigitCount(py_long o, int sign, Py_ssize_t size)


### PR DESCRIPTION
The necessary functions are copied from cpython 3.12 `Include/internal/pycore_long.h`, which is private. This should make it easy to copy new versions if cpython internals change. For cpython < 3.12 I implemented equivalent functions.

All of this is placed in separate files `pycore_long.pxd` and `pycore_long.h` so it's easy to share between projects (fpylll, sagemath).

Tested in 64-bit and 32-bit x86.

Fixes: #137