### PR TITLE
Add pyproject.toml, update installation instructions for modern Python packaging, fix docbuild, update CI scripts, add Cython 3 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            pip install sphinx cython cysignals
+            pip install sphinx cython cysignals setuptools
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
           run: |
             python3 -m venv tvenv
             . tvenv/bin/activate
-            pip install setuptools sphinx cython cysignals -U
+            pip install -Iv setuptools==68.2.2
+            pip install sphinx cython cysignals
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,7 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            python3 -m venv tvenv
-            . tvenv/bin/activate
-            pip install sphinx
             make install
             make check
+            pip install sphinx
             (cd docs && make html)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,6 @@ jobs:
             . tvenv/bin/activate
             pip install -Iv setuptools==68.2.2
             pip install sphinx cython cysignals wheel
-            make build
             make install
             make check
             (cd docs && make html)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.6', '3.10', '3.11']
-                pari-version: ['pari-2.9.5', 'pari-2.11.4', 'pari-2.13.0', 'pari-2.15.1']
+                python-version: ['3.10', '3.11']
+                pari-version: ['pari-2.11.4', 'pari-2.13.0', 'pari-2.15.4']
         env:
           LC_ALL: C
           PARI_VERSION: ${{ matrix.pari-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
+            pip install setuptools -U
+            pip install sphinx cython cysignals
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            pip install sphinx cython cysignals setuptools
+            pip install setuptools
+            pip install sphinx cython cysignals
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            pip install setuptools>67
-            pip install sphinx cython cysignals
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,9 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            pip install setuptools -U
-            pip install sphinx cython cysignals
+            python3 -m venv tvenv
+            . tvenv/bin/activate
+            pip install setuptools sphinx cython cysignals -U
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
               bash -x .install-pari.sh
         - name: Local build
           run: |
-            pip install setuptools
+            pip install setuptools>67
             pip install sphinx cython cysignals
             make build
             make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             python3 -m venv tvenv
             . tvenv/bin/activate
             pip install -Iv setuptools==68.2.2
-            pip install sphinx cython cysignals
+            pip install sphinx cython cysignals wheel
             make build
             make install
             make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,6 @@ jobs:
             python-version: ${{ matrix.python-version }}
         - name: Install pari
           run: |
-              ccache -M 256M && ccache -s
-              export PATH="/usr/lib/ccache:$PATH"
               bash -x .install-pari.sh
         - name: Local build
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
           run: |
             python3 -m venv tvenv
             . tvenv/bin/activate
-            pip install -Iv setuptools==68.2.2
-            pip install sphinx cython cysignals wheel
+            pip install sphinx
             make install
             make check
             (cd docs && make html)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PIP = $(PYTHON) -m pip -v
 
 
 install:
-	$(PIP) install --no-index --upgrade --no-build-isolation .
+	$(PIP) install --upgrade --no-build-isolation .
 
 check:
 	ulimit -s 8192; $(PYTHON) -u tests/rundoctest.py

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PIP = $(PYTHON) -m pip -v
 
 
 install:
-	$(PIP) install --upgrade --no-build-isolation .
+	$(PIP) install --upgrade .
 
 check:
 	ulimit -s 8192; $(PYTHON) -u tests/rundoctest.py

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ PYTHON = python
 PIP = $(PYTHON) -m pip -v
 
 
-build:
-	$(PYTHON) setup.py build
-
 install:
 	$(PIP) install --no-index --upgrade --no-build-isolation .
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	$(PYTHON) setup.py build
 
 install:
-	$(PIP) install --no-index --upgrade .
+	$(PIP) install --no-index --upgrade --no-build-isolation .
 
 check:
 	ulimit -s 8192; $(PYTHON) -u tests/rundoctest.py

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ check:
 
 dist:
 	chmod go+rX-w -R .
-	umask 0022 && $(PYTHON) setup.py sdist --formats=gztar
+	$(PIP) install build
+	umask 0022 && $(PYTHON) -m build --sdist
 
 
-.PHONY: build install check dist
+.PHONY: install check dist

--- a/README.rst
+++ b/README.rst
@@ -10,22 +10,20 @@ A Python interface to the number theory library `PARI/GP <http://pari.math.u-bor
 Installation
 ------------
 
-GNU/Linux
-^^^^^^^^^
+From a distribution package (GNU/Linux, conda-forge)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A package `python-cypari2` or `python2-cypari2` or `python3-cypari2` might be
-available in your package manager.
+A package might be available in your package manager, see
+https://repology.org/project/python:cypari2/versions
 
-Using pip
-^^^^^^^^^
+From source with pip
+^^^^^^^^^^^^^^^^^^^^
 
 Requirements:
 
 - PARI/GP >= 2.9.4 (header files and library)
 - Python >= 3.6
 - pip
-- `cysignals <https://pypi.python.org/pypi/cysignals/>`_ >= 1.7
-- Cython >= 0.29
 
 Install cypari2 via the Python Package Index (PyPI) via
 
@@ -34,10 +32,13 @@ Install cypari2 via the Python Package Index (PyPI) via
     $ pip install cypari2 [--user]
 
 (the optional option *--user* allows to install cypari2 for a single user
-and avoids using pip with administrator rights). Depending on your operating
-system the pip command might also be called pip3.
+and avoids using pip with administrator rights).
 
-If you want to try the development version use
+`pip` builds the package using build isolation.  All Python build dependencies
+of the package, declared in pyproject.toml, are automatically installed in
+a temporary virtual environment.
+
+If you want to try the development version, use
 
 ::
 
@@ -50,12 +51,6 @@ already installed, try to reinstall cysignals and cypari2
 
     $ pip install cysignals --upgrade [--user]
     $ pip install cypari2 --upgrade [--user]
-
-Other
-^^^^^
-
-Any other way to install cypari2 is not supported. In particular, ``python
-setup.py install`` will produce an error.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,10 @@ From source with pip
 
 Requirements:
 
-- PARI/GP >= 2.9.4 (header files and library)
+- PARI/GP >= 2.9.4 (header files and library); see
+  https://doc.sagemath.org/html/en/reference/spkg/pari#spkg-pari
+  for availability in distributions (GNU/Linux, conda-forge, Homebrew, FreeBSD),
+  or install from source.
 - Python >= 3.6
 - pip
 

--- a/_custom_build_meta.py
+++ b/_custom_build_meta.py
@@ -1,0 +1,2 @@
+# See https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+from setuptools.build_meta import *

--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -329,7 +329,7 @@ cdef class Gen(Gen_base):
         >>> pari = Pari()
         >>> L = pari("vector(10,i,i^2)")
         >>> L.__iter__()
-        <generator object at ...>
+        <...generator object at ...>
         >>> [x for x in L]
         [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
         >>> list(L)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'CyPari2'
-copyright = u'2017, Many people'
-author = u'Many people'
+project = 'CyPari2'
+copyright = '2017, Many people'
+author = 'Many people'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -68,7 +68,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+#language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -160,13 +160,14 @@ texinfo_documents = [
 
 # Links to external resources (copied from Sage)
 extlinks = {
-    'trac': ('https://trac.sagemath.org/%s', 'Sage ticket #'),
-    'wikipedia': ('https://en.wikipedia.org/wiki/%s', 'Wikipedia article '),
-    'arxiv': ('http://arxiv.org/abs/%s', 'Arxiv '),
-    'oeis': ('https://oeis.org/%s', 'OEIS sequence '),
-    'doi': ('https://dx.doi.org/%s', 'doi:'),
-    'pari': ('http://pari.math.u-bordeaux.fr/dochtml/help/%s', 'pari:'),
-    'mathscinet': ('http://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet ')
+    'trac': ('https://github.com/sagemath/sage/issues/%s', 'github issue #%s'), # support :trac: for backward compatibility
+    'issue': ('https://github.com/sagemath/sage/issues/%s', 'github issue #%s'),
+    'wikipedia': ('https://en.wikipedia.org/wiki/%s', 'Wikipedia article %s'),
+    'arxiv': ('https://arxiv.org/abs/%s', 'arXiv %s'),
+    'oeis': ('https://oeis.org/%s', 'OEIS sequence %s'),
+    'doi': ('https://dx.doi.org/%s', 'doi:%s'),
+    'pari': ('https://pari.math.u-bordeaux.fr/dochtml/help/%s', 'pari:%s'),
+    'mathscinet': ('https://www.ams.org/mathscinet-getitem?mr=%s', 'MathSciNet %s')
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools",
-            "Cython>=0.29",
+            "Cython>=0.29,<3",
             "cysignals>=1.7"]
 # We need access to the autogen package at build time.
 # Hence we declare a custom build backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools",
+            "Cython>=0.29",
+            "cysignals>=1.7"]
+# We need access to the autogen package at build time.
+# Hence we declare a custom build backend.
+build-backend = "_custom_build_meta"  # just re-exports setuptools.build_meta definitions
+backend-path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0",
+requires = ["setuptools",
             "Cython>=0.29",
             "cysignals>=1.7"]
 # We need access to the autogen package at build time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools",
+requires = ["setuptools>=68.0",
             "Cython>=0.29",
             "cysignals>=1.7"]
 # We need access to the autogen package at build time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools",
-            "Cython>=0.29,<3",
+            "Cython>=0.29",
             "cysignals>=1.7"]
 # We need access to the autogen package at build time.
 # Hence we declare a custom build backend.

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ with open('VERSION') as f:
 setup(
     name='cypari2',
     version=VERSION,
-    setup_requires=['Cython>=0.29'],
     install_requires=['cysignals>=1.7'],
     description="A Python interface to the number theory library PARI/GP",
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ class build_ext(_build_ext):
             "binding": True,
             "cdivision": True,
             "language_level": 2,
+            "legacy_implicit_noexcept": True,
+            "c_api_binop_methods": True,
         }
 
         _build_ext.finalize_options(self)


### PR DESCRIPTION
This PR started out with minimal changes, replacing the outdated use of `setup_requires`.

Fixes #93 
(with a cleaner solution for augmenting the build-time path than the stalled PR #104).
