### PR TITLE
.github/workflows/wheels.yml: New

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,83 @@
+name: Build wheels
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Cancel previous runs of this workflow for the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  sdists_for_pypi:
+    name: Build sdist (and upload to PyPI on release tags)
+    runs-on: ubuntu-latest
+    env:
+      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+      - name: make sdist
+        run: |
+          python3 -m pip install build
+          python3 -m build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: "dist/*.tar.gz"
+          name: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
+          skip_existing: true
+          verbose: true
+        if: env.CAN_DEPLOY == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.0
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+
+  pypi-publish:
+    # https://github.com/pypa/gh-action-pypi-publish
+    name: Upload wheels to PyPI
+    needs: build_wheels
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    env:
+      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
+    steps:
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
+          packages_dir: wheelhouse/
+          skip_existing: true
+          verbose: true
+        if: env.CAN_DEPLOY == 'true'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,6 +19,11 @@ jobs:
       CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install pari
+        run: |
+          bash -x .install-pari.sh
+        env:
+          PARI_VERSION: pari-2.15.4
       - uses: actions/setup-python@v4
       - name: make sdist
         run: |
@@ -37,20 +42,61 @@ jobs:
         if: env.CAN_DEPLOY == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }}, arch ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    needs: sdists_for_pypi
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest]
-
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: i686
+          - os: macos-latest
+            arch: auto
+    env:
+      # SPKGs to install as system packages
+      SPKGS: _bootstrap _prereq
+      # Non-Python packages to install as spkgs
+      TARGETS_PRE: pari
+      # Disable building PyPy wheels on all platforms
+      # Disable musllinux until #33083 provides alpine package information
+      CIBW_SKIP: "pp* *-musllinux*"
+      #
+      CIBW_ARCHS: ${{ matrix.arch }}
+      # https://cibuildwheel.readthedocs.io/en/stable/options/#requires-python
+      CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+      # Environment during wheel build
+      CIBW_ENVIRONMENT: "PATH=$(pwd)/local/bin:$PATH CPATH=$(pwd)/local/include:$CPATH LIBRARY_PATH=$(pwd)/local/lib:$LIBRARY_PATH PKG_CONFIG_PATH=$(pwd)/local/share/pkgconfig:$PKG_CONFIG_PATH ACLOCAL_PATH=/usr/share/aclocal"
+      # Use 'build', not 'pip wheel'
+      CIBW_BUILD_FRONTEND: build
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository:   sagemath/sage
+          ref:          develop
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.0
+      - name: Build platform wheels
+        # We build the wheel from the sdist.
+        # But we must run cibuildwheel with the unpacked source directory, not a tarball,
+        # so that SAGE_ROOT is copied into the build containers.
+        #
+        # In the CIBW_BEFORE_ALL phase, we install libraries using the Sage distribution.
+        # https://cibuildwheel.readthedocs.io/en/stable/options/#before-all
+        run: |
+          export PATH=build/bin:$PATH
+          export CIBW_BEFORE_ALL="( $(sage-print-system-package-command debian --yes --no-install-recommends install $(sage-get-system-packages debian $SPKGS)) || $(sage-print-system-package-command fedora --yes --no-install-recommends install $(sage-get-system-packages fedora $SPKGS | sed s/pkg-config/pkgconfig/)) || ( $(sage-print-system-package-command homebrew --yes --no-install-recommends install $(sage-get-system-packages homebrew $SPKGS)) || echo error ignored) ) && ./bootstrap && ./configure --enable-build-as-root && make -j4 V=0 $TARGETS_PRE"
+          mkdir -p unpacked
+          for pkg in cypari2; do
+              (cd unpacked && tar xfz - ) < dist/$pkg*.tar.gz
+              pipx run cibuildwheel==2.16.0 unpacked/$pkg*
+          done
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,7 +68,7 @@ jobs:
       # https://cibuildwheel.readthedocs.io/en/stable/options/#requires-python
       CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
       # Environment during wheel build
-      CIBW_ENVIRONMENT: "PATH=$(pwd)/local/bin:$PATH CPATH=$(pwd)/local/include:$CPATH LIBRARY_PATH=$(pwd)/local/lib:$LIBRARY_PATH PKG_CONFIG_PATH=$(pwd)/local/share/pkgconfig:$PKG_CONFIG_PATH ACLOCAL_PATH=/usr/share/aclocal"
+      CIBW_ENVIRONMENT: "PATH=$(pwd)/local/bin:$PATH CPATH=$(pwd)/local/include:$CPATH LIBRARY_PATH=$(pwd)/local/lib:$LIBRARY_PATH LD_LIBRARY_PATH=$(pwd)/local/lib:$LD_LIBRARY_PATH PKG_CONFIG_PATH=$(pwd)/local/share/pkgconfig:$PKG_CONFIG_PATH ACLOCAL_PATH=/usr/share/aclocal"
       # Use 'build', not 'pip wheel'
       CIBW_BUILD_FRONTEND: build
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,6 +84,14 @@ jobs:
           name: dist
           path: dist
 
+      - uses: actions/setup-python@v5
+        # As of 2024-02-03, the macOS M1 runners do not have preinstalled python or pipx.
+        # Installing pipx follows the approach of https://github.com/pypa/cibuildwheel/pull/1743
+        id: python
+        with:
+          python-version: "3.8 - 3.12"
+          update-environment: false
+
       - name: Build platform wheels
         # We build the wheel from the sdist.
         # But we must run cibuildwheel with the unpacked source directory, not a tarball,
@@ -92,12 +100,13 @@ jobs:
         # In the CIBW_BEFORE_ALL phase, we install libraries using the Sage distribution.
         # https://cibuildwheel.readthedocs.io/en/stable/options/#before-all
         run: |
+          "${{ steps.python.outputs.python-path }}" -m pip install pipx
           export PATH=build/bin:$PATH
           export CIBW_BEFORE_ALL="( $(sage-print-system-package-command debian --yes --no-install-recommends install $(sage-get-system-packages debian $SPKGS)) || $(sage-print-system-package-command fedora --yes --no-install-recommends install $(sage-get-system-packages fedora $SPKGS | sed s/pkg-config/pkgconfig/)) || ( $(sage-print-system-package-command homebrew --yes --no-install-recommends install $(sage-get-system-packages homebrew $SPKGS)) || echo error ignored) ) && ./bootstrap && ./configure --enable-build-as-root && make -j4 V=0 $TARGETS_PRE"
           mkdir -p unpacked
           for pkg in cypari2; do
               (cd unpacked && tar xfz - ) < dist/$pkg*.tar.gz
-              pipx run cibuildwheel==2.17.0 unpacked/$pkg*
+              "${{ steps.python.outputs.python-path }}" -m pipx run cibuildwheel==2.17.0 unpacked/$pkg*
           done
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,6 +55,8 @@ jobs:
             arch: i686
           - os: macos-latest
             arch: auto
+          - os: macos-14
+            arch: auto
     env:
       # SPKGs to install as system packages
       SPKGS: _bootstrap _prereq
@@ -95,7 +97,7 @@ jobs:
           mkdir -p unpacked
           for pkg in cypari2; do
               (cd unpacked && tar xfz - ) < dist/$pkg*.tar.gz
-              pipx run cibuildwheel==2.16.0 unpacked/$pkg*
+              pipx run cibuildwheel==2.17.0 unpacked/$pkg*
           done
 
       - uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,9 @@ keywords = ["PARI/GP number theory"]
 
 [project.urls]
 Homepage = "https://github.com/sagemath/cypari2"
+[tool.cibuildwheel]
+before-all = """
+  apt-get install --yes wget sudo || yum install -y wget sudo || brew install bash coreutils
+  bash -x ./.install-pari.sh
+"""
+environment = { PARI_VERSION="pari-2.15.4" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,3 @@ keywords = ["PARI/GP number theory"]
 
 [project.urls]
 Homepage = "https://github.com/sagemath/cypari2"
-[tool.cibuildwheel]
-before-all = """
-  apt-get install --yes wget sudo || yum install -y wget sudo || brew install bash coreutils
-  bash -x ./.install-pari.sh
-"""
-environment = { PARI_VERSION="pari-2.15.4" }


### PR DESCRIPTION
We add a GH Actions workflow that builds sdists and wheels for PyPI.

Wheel-building uses the Sage distribution to build the prerequisites from scratch.
This can later be refactored using a reusable workflow - https://github.com/sagemath/sage/pull/36525

Resolves #105.
