### PR TITLE
Fix typo for Python <= 3.8.

### DIFF
--- a/cypari2/pycore_long.h
+++ b/cypari2/pycore_long.h
@@ -89,7 +89,7 @@ _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
 {
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9)
 // The function Py_SET_SIZE is defined starting with python 3.9.
-    Py_SIZE(o) = size;
+    Py_SIZE(op) = size;
 #else
     Py_SET_SIZE(op, sign < 0 ? -size : size);
 #endif


### PR DESCRIPTION
This was introduced by accident in #138.

The typo leads to errors like below, when trying to build for Python <= 3.8:
```C
gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DOPENSSL_NO_SSL3 -fPIC -Icypari2 -I/tmp/virt/lib/python3.8/site-packages/cysignals -I/usr/include -I/tmp/virt/include -I/home/jjan/.pyenv/versions/3.8.18/include/python3.8 -c cypari2/convert.c -o build/temp.linux-x86_64-3.8/cypari2/convert.o
In file included from /home/jjan/.pyenv/versions/3.8.18/include/python3.8/pytime.h:6,
                 from /home/jjan/.pyenv/versions/3.8.18/include/python3.8/Python.h:85,
                 from cypari2/convert.c:49:
cypari2/pycore_long.h: In function ‘_PyLong_SetSignAndDigitCount’:
cypari2/pycore_long.h:92:13: error: ‘o’ undeclared (first use in this function); did you mean ‘op’?
   92 |     Py_SIZE(o) = size;
      |             ^
/home/jjan/.pyenv/versions/3.8.18/include/python3.8/object.h:119:47: note: in definition of macro ‘_PyVarObject_CAST’
  119 | #define _PyVarObject_CAST(op) ((PyVarObject*)(op))
      |                                               ^~
cypari2/pycore_long.h:92:5: note: in expansion of macro ‘Py_SIZE’
   92 |     Py_SIZE(o) = size;
      |     ^~~~~~~
cypari2/pycore_long.h:92:13: note: each undeclared identifier is reported only once for each function it appears in
   92 |     Py_SIZE(o) = size;
      |             ^
/home/jjan/.pyenv/versions/3.8.18/include/python3.8/object.h:119:47: note: in definition of macro ‘_PyVarObject_CAST’
  119 | #define _PyVarObject_CAST(op) ((PyVarObject*)(op))
      |                                               ^~
cypari2/pycore_long.h:92:5: note: in expansion of macro ‘Py_SIZE’
   92 |     Py_SIZE(o) = size;
      |     ^~~~~~~
error: command 'gcc' failed with exit status 1
```