### PR TITLE
Require Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev']
                 pari-version: ['pari-2.11.4', 'pari-2.13.0', 'pari-2.15.4']
         env:
           LC_ALL: C

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev']
-                pari-version: ['pari-2.11.4', 'pari-2.13.0', 'pari-2.15.4']
+                pari-version: ['pari-2.11.4', 'pari-2.13.0', 'pari-2.15.4', 'pari-2.15.5']
         env:
           LC_ALL: C
           PARI_VERSION: ${{ matrix.pari-version }}

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements:
   https://doc.sagemath.org/html/en/reference/spkg/pari#spkg-pari
   for availability in distributions (GNU/Linux, conda-forge, Homebrew, FreeBSD),
   or install from source.
-- Python >= 3.6
+- Python >= 3.9
 - pip
 
 Install cypari2 via the Python Package Index (PyPI) via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 dependencies = [
     "cysignals>=1.7",
 ]
+requires-python = ">=3.9"
 readme = "README.rst"
 license = {text = "GNU General Public License, version 2 or later"}
 keywords = ["PARI/GP number theory"]


### PR DESCRIPTION
build with Python 3.8 seems to fail with

```
In file included from /home/conda/feedstock_root/build_artifacts/cypari2_1705557903378/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/include/python3.8/pytime.h:6,
                   from /home/conda/feedstock_root/build_artifacts/cypari2_1705557903378/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/include/python3.8/Python.h:85,
                   from cypari2/convert.c:50:
  cypari2/pycore_long.h: In function '_PyLong_SetSignAndDigitCount':
  cypari2/pycore_long.h:92:13: error: 'o' undeclared (first use in this function); did you mean 'op'?
     92 |     Py_SIZE(o) = size;
        |
```

also our CI only tests with Python 3.9+ so that seem to be required by now.

In any case, active support for Python 3.8 ended May 2021 and security support is going to end in October 2024.