### PR TITLE
move generation of pari bindings sources out of build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ from autogen.paths import include_dirs, library_dirs
 
 ext_kwds = dict(include_dirs=include_dirs(), library_dirs=library_dirs())
 
+# Generate auto-generated sources from pari.desc
+# This needs to be done before build/build_ext so the generated pxd is moved
+# to the build directory and installed with newer setuptools.
+rebuild()
 
 if "READTHEDOCS" in os.environ:
     # When building with readthedocs, disable optimizations to decrease
@@ -28,9 +32,6 @@ if "READTHEDOCS" in os.environ:
 # Adapted from Cython's new_build_ext
 class build_ext(_build_ext):
     def finalize_options(self):
-        # Generate auto-generated sources from pari.desc
-        rebuild()
-
         self.directives = {
             "autotestdict.cdef": True,
             "binding": True,


### PR DESCRIPTION
I have been sitting on this one for a while as I was seeing it as a corner case that only shows up in a rare workflows. But I know think it is evidence of something done incorrectly that could affect everyone if setuptools tighten up the install process.

So, what is this supposed to fix:
In the normal production of binary wheel, you would get the sdist, build the wheel for a version of python and start from scratch for every version of python.

In Gentoo where we allow for multiple python on the system, you unfold the sdist and since building python package is essentially an out of source process, you build for all your python implementations from the same source directory (usually).

In this setup the current `setup.py` will generate the `.pxd` files for the first python implementation being built and they will be shipped for that python implementation. Further python implementations will not generate a new version of `.pxd` files and will use the ones generated by the first implementation - but they will not get shipped (even with `package_data` saying that they should be). This is essentially because the `.pxd` files are generated in the source tree.

This PR makes the `.pxd` files to be generated in the python implementation build tree instead of the source tree. This ensure that they are generated with the right version of python and always shipped.

Given the observed behaviour, I have concerns that a future version of setuptools could just stop shipping `.pxd` files generated in the source directory as part of the build process.