### PR TITLE
Add missing noexcept clauses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cypari2/auto_paridecl.pxd.tmp
 cypari2/auto_paridecl.pxd
 cypari2/closure.c
 cypari2/convert.c
+cypari2/custom_block.c
 cypari2/gen.c
 cypari2/handle_error.c
 cypari2/pari_instance.c

--- a/cypari2/custom_block.pyx
+++ b/cypari2/custom_block.pyx
@@ -12,14 +12,14 @@ from cysignals.signals cimport add_custom_signals
 cdef extern from "pari/pari.h":
     int     PARI_SIGINT_block, PARI_SIGINT_pending
 
-cdef int custom_signal_is_blocked():
+cdef int custom_signal_is_blocked() noexcept:
     return PARI_SIGINT_block
 
-cdef void custom_signal_unblock():
+cdef void custom_signal_unblock() noexcept:
     global PARI_SIGINT_block
     PARI_SIGINT_block = 0
 
-cdef void custom_set_pending_signal(int sig):
+cdef void custom_set_pending_signal(int sig) noexcept:
     global PARI_SIGINT_pending
     PARI_SIGINT_pending = sig
 


### PR DESCRIPTION
These functions clearly don't raise any python exception.

They were introduced in #130 which wasn't merged when I prepared #160.