### PR TITLE
Synchronize cypari2 stack and Python lifecycle

### DIFF
--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -154,13 +154,21 @@ cdef class Gen(Gen_base):
     def __init__(self):
         raise RuntimeError("PARI objects cannot be instantiated directly; use pari(x) to convert x to PARI")
 
+    def __del__(self):
+        if self.get_next() is not None:
+            # Python can deallocate Gen at any time even when it is not
+            # at the stack bottom. When self is not at the stack
+            # bottom, we need to move everything below it to heap
+            # before deallocation.
+            move_gens_to_heap(self.sp())
+
     def __dealloc__(self):
-        if self.next is not None:
+        if self.get_next() is not None:
             # stack
             remove_from_pari_stack(self)
         elif self.address is not NULL:
             # clone
-            gunclone_deep(self.address)
+            gunclone(self.address)
 
     cdef Gen new_ref(self, GEN g):
         """
@@ -191,7 +199,7 @@ cdef class Gen(Gen_base):
         >>> pari("[[1, 2], 3]")[0][1]  # indirect doctest
         2
         """
-        if self.next is not None:
+        if self.get_next() is not None:
             raise TypeError("cannot create reference to PARI stack (call fixGEN() first)")
         if is_on_stack(g):
             raise ValueError("new_ref() called with GEN which does not belong to parent")
@@ -205,8 +213,8 @@ cdef class Gen(Gen_base):
         Return the PARI ``GEN`` corresponding to ``self`` which is
         guaranteed not to change.
         """
-        if self.next is not None:
-            move_gens_to_heap(self.sp())
+        if self.get_next() is not None:
+            move_gens_to_heap((<Gen>self.get_next()).sp())
         return self.g
 
     cdef GEN ref_target(self) except NULL:
@@ -1532,7 +1540,7 @@ cdef class Gen(Gen_base):
                 raise IndexError("column j(=%s) must be between 0 and %s" % (j, self.ncols()-1))
 
             self.cache((i, j), x)
-            xt = x.ref_target()
+            xt = x.fixGEN()
             set_gcoeff(self.g, i+1, j+1, xt)
             return
 
@@ -1556,7 +1564,7 @@ cdef class Gen(Gen_base):
             raise IndexError("index (%s) must be between 0 and %s" % (i, glength(self.g)-1))
 
         self.cache(i, x)
-        xt = x.ref_target()
+        xt = x.fixGEN()
         if typ(self.g) == t_LIST:
             listput(self.g, xt, i+1)
         else:
@@ -4631,7 +4639,7 @@ cdef class Gen(Gen_base):
 cdef int Gen_clear(self) except -1:
     """
     Implementation of tp_clear() for Gen. We need to override Cython's
-    default since we do not want self.next to be cleared: it is crucial
+    default since we do not want self._next to be cleared: it is crucial
     that the next Gen stays alive until remove_from_pari_stack(self) is
     called by __dealloc__.
     """

--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -1269,7 +1269,7 @@ cdef class Pari(Pari_auto):
                 for j in range(n):
                     sig_check()
                     x = objtogen(entries[k])
-                    set_gcoeff(A.g, i+1, j+1, x.ref_target())
+                    set_gcoeff(A.g, i+1, j+1, x.fixGEN())
                     A.cache((i, j), x)
                     k += 1
         return A


### PR DESCRIPTION
This PR attempts to fix #112.

As explained in #112, the main reason for the leak is that the cypari2 stack (not to be confused with PARI stack) holds ownership of the Gen objects. Therefore, the primary way for the Gen objects to be cleaned up is when the cypari2 stack reaches a certain threshold (half the maximum size) that triggers a cleanup.

For example, consider the following example from #112:
```
while True:
  M = pari.matrix(10, 10, range(100))
```
The behavior before this PR: on the second iteration, the old value of `M` is not deallocated because the cypari2 stack still holds a reference to it.

This PR solves this problem mainly by replacing cypari2 stack's reference to the Gens object to use weakref. In the above example, after this PR, on the second iteration, the old value of `M` will be deallocated because cypari2 only holds a weak reference to `M`, not a strong reference.

Therefore, the primary change introduced here is to replace `Gen.next` with a weak reference. To accommodate that, the following changes are made:
1. Because there is no hidden ownership by cypari2 stack, `Gen` object deallocations now can happen more often and in any order. When the `Gen` object is in the middle of cypari2 stack, we need to move everything below it to the heap to avoid the stack being fragmented.
2. Each object is now responsible only for its `gunclone` (hence, no `gunclone_deep`), even if it is a container type like matrix or vector. Therefore, an object in the PARI heap only needs a reference count of 1 and never needs to be 2, removing the complications of `ref_target` (which can increase ref count by 2). At the Python level, non-default entries are hold in `Gen.itemcache` of its container and will be deallocated when the `itemcache` is cleared. There is an exception for this and it is documented in the comment inside the `move_gens_to_heap` method.

The PR was tested with `make check` and memory leak checks similar to examples given in #112.

As a note, there is a tricky side effect of this PR explained in: https://github.com/sagemath/cypari2/pull/180#issuecomment-3061858665