### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,20 +103,6 @@ jobs:
           docker_push_repository: ghcr.io/${{ github.repository }}/cypari2-
         needs: [linux-sage]
 
-    macos-sage:
-        uses: sagemath/sage/.github/workflows/macos.yml@develop
-        with:
-          osversion_xcodeversion_toxenv_tuples: >-
-            [["latest", "",           "homebrew-macos-usrlocal-minimal"],
-             ["latest", "",           "homebrew-macos-usrlocal-standard"],
-             ["latest", "",           "conda-forge-macos-standard"]]
-          targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cypari" cypari
-          # Standard setting: Test the current beta release of Sage
-          sage_repo:         sagemath/sage
-          sage_ref:          develop
-          upstream_artifact: upstream
-        needs: [dist]
-
 env:
     # Ubuntu packages to install so that the project's "setup.py sdist" can succeed
     DIST_PREREQ: libpari-dev pari-doc libbz2-dev bzip2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,8 @@ jobs:
           # We prefix the image name with the SPKG name ("cypari2-") to avoid the error
           # 'Package "sage-docker-..." is already associated with another repository.'
           docker_push_repository: ghcr.io/${{ github.repository }}/cypari2-
+          tox_packages_factors: >-
+            ["standard"]
         needs: [dist]
 
     linux-sage-incremental:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: cypari2
 
 on:
     pull_request:
-        types: [opened, synchronize]
     push:
         tags:
             - '*'
@@ -21,8 +20,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11', '3.12', '3.13-dev']
-                pari-version: ['pari-2.13.0', 'pari-2.15.4', 'pari-2.15.5', '2.17.1']
+                python-version: ['3.10', '3.11', '3.12', '3.13']
+                pari-version: ['pari-2.13.0', 'pari-2.15.4', 'pari-2.15.5', '2.17.2']
         env:
           LC_ALL: C
           PARI_VERSION: ${{ matrix.pari-version }}
@@ -69,7 +68,7 @@ jobs:
               path: upstream
               name: upstream
 
-    linux-sage:
+    sage:
         uses: sagemath/sage/.github/workflows/docker.yml@develop
         with:
           targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="cypari" cypari
@@ -83,27 +82,6 @@ jobs:
           tox_packages_factors: >-
             ["standard"]
         needs: [dist]
-
-    linux-sage-incremental:
-        uses: sagemath/sage/.github/workflows/docker.yml@develop
-        with:
-          # Build incrementally from published Docker image
-          incremental: true
-          free_disk_space: true
-          from_docker_repository: ghcr.io/sagemath/sage/
-          from_docker_target: "with-targets"
-          from_docker_tag: "dev"
-          docker_targets: "with-targets"
-          targets_pre:       build/make/Makefile
-          targets:           "cypari-uninstall build doc-html ptest"
-          targets_optional:  build/make/Makefile
-          sage_repo:         sagemath/sage
-          sage_ref:          develop
-          upstream_artifact: upstream
-          # We prefix the image name with the SPKG name ("cypari2-") to avoid the error
-          # 'Package "sage-docker-..." is already associated with another repository.'
-          docker_push_repository: ghcr.io/${{ github.repository }}/cypari2-
-        needs: [linux-sage]
 
 env:
     # Ubuntu packages to install so that the project's "setup.py sdist" can succeed


### PR DESCRIPTION
The CI is currently failing (see https://github.com/sagemath/cypari2/actions/runs/17200257815) as it refers to a macos-workflow in the sage repo that has been removed. Even when they were still running, they failed: https://github.com/sagemath/cypari2/actions/runs/14972846870/job/42057916879. Readding macos runs will be done in a future PR (it's already in https://github.com/sagemath/cypari2/pull/186 but I'll extract it to another PR that can be more easily reviewed)

We also remove the offending step here, and also remove all minimal runs (they are already removed in sage and were mostly failing see https://github.com/sagemath/cypari2/actions/runs/17587391696) and the "sage incremental" (they were taking quite long and were also mostly failing without testing anything really new https://github.com/sagemath/cypari2/actions/runs/17588348387/job/49964966738?pr=187). 

Finally, also update python to 3.13 and pari to latest released 2.17.2