### PR TITLE
refactor the exception handle in after sig_on()

### DIFF
--- a/cypari2/custom_block.pyx
+++ b/cypari2/custom_block.pyx
@@ -6,6 +6,7 @@
 #*****************************************************************************
 
 from cysignals.signals cimport add_custom_signals
+from .stack cimport reset_avma
 
 cdef extern from "pari/pari.h":
     int     PARI_SIGINT_block, PARI_SIGINT_pending
@@ -16,6 +17,7 @@ cdef int custom_signal_is_blocked() noexcept:
 cdef void custom_signal_unblock() noexcept:
     global PARI_SIGINT_block
     PARI_SIGINT_block = 0
+    reset_avma()
 
 cdef void custom_set_pending_signal(int sig) noexcept:
     global PARI_SIGINT_pending


### PR DESCRIPTION
The root cause was in the autogenerated PARI wrappers: they cleaned up the PARI stack only on success. On interrupts or PARI exceptions, `avma` was left stale, which produced the `cypari2 leaked ... on the PARI stack` warnings. 

Fix https://github.com/sagemath/sage/issues/40813