### PR TITLE
copy __init__.py to build dir

### DIFF
--- a/cypari2/meson.build
+++ b/cypari2/meson.build
@@ -55,3 +55,8 @@ configure_file(
   install: true,
   install_dir: py.get_install_dir() / 'cypari2'
 )
+configure_file(
+  input: '__init__.py',
+  output: '__init__.py',
+  copy: true,
+)

--- a/meson.build
+++ b/meson.build
@@ -128,6 +128,7 @@ endif
 message('PARI Datadir: ' + pari_datadir)
 
 # Run code generation step
+message('Generating PARI functions ...')
 code_gen_result = run_command(
   py.full_path(), '-c',
   '''
@@ -139,6 +140,7 @@ print("Code generation successful")
   ''',
   check: true
 )
+message('                          ... DONE')
 py.install_sources(
   meson.current_build_dir() + '/cypari2/auto_paridecl.pxd',
   meson.current_build_dir() + '/cypari2/auto_gen.pxi',


### PR DESCRIPTION
This allows one to use something like
```
meson setup build && ninja -C build
PYTHONPATH=build make check
```
to check using the current build.

Without the `__init__.py` file in there, the system installation of cypari takes precedence.

I also added a (trivial) commit to print a message before starting autogen, which takes a long time.
