### PR TITLE
Pin macOS arm64 wheels to macOS 15

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -36,7 +36,8 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-15-intel
-          - macos-latest
+          # Pin arm64 so Homebrew libraries support the 15.0 wheel target.
+          - macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary

- pin the Apple silicon wheel builder to `macos-15`
- retain the existing macOS 15 deployment target and Intel wheel builder

## Root cause

`macos-latest` now resolves to a macOS 26 arm64 runner. Homebrew therefore installs PARI and GMP libraries whose minimum deployment target is macOS 26, while cibuildwheel produces a `macosx_15_0_arm64` wheel. `delocate` correctly rejects those libraries as incompatible with the wheel target.

Pinning the arm64 runner to macOS 15 keeps the Homebrew libraries compatible with the intended wheel target. Raising the deployment target to macOS 26 would instead drop support for macOS 15 through 25.

Failing job: https://github.com/sagemath/cypari2/actions/runs/30241114623/job/89898340441

## Validation

- parsed `.github/workflows/dist.yml` with PyYAML
- asserted that the matrix contains `macos-15-intel` and `macos-15`, with `MACOSX_DEPLOYMENT_TARGET` still set to `15.0`
- ran `git diff --check upstream/main..HEAD`
