### PR TITLE
Bump default PARI version to 2.17.4

### DIFF
--- a/.install-pari.sh
+++ b/.install-pari.sh
@@ -45,7 +45,7 @@ if [ -n "$CONDA_PREFIX" ]; then
 fi
 
 if [ "$PARI_VERSION" = "" ]; then
-    PARI_VERSION=2.17.3
+    PARI_VERSION=2.17.4
 fi
 
 PURE_VERSION=${PARI_VERSION/pari-}


### PR DESCRIPTION
## Summary

- update the default PARI version in `.install-pari.sh` from 2.17.3 to 2.17.4
- keep `PARI_VERSION` overrides unchanged

## Impact

CI and local users that run the helper script without setting `PARI_VERSION` will build against PARI 2.17.4.

## Validation

- `bash -n .install-pari.sh`
- `git diff --check`
