### PR TITLE
Fix idealfrobenius for heap-cloned Galois data

### DIFF
--- a/autogen/generator.py
+++ b/autogen/generator.py
@@ -74,9 +74,9 @@ function_blacklist = {"O",            # O(p^e) needs special parser support
                       "my",           # idem
                       }
 
-# Functions that return a reference to internal PARI state
-# and need gcopy() to avoid double-free bugs
-gcopy_return_functions = {"addprimes", "removeprimes"}
+# Functions that return borrowed references instead of new stack values
+# and need gcopy() before wrapping the result
+gcopy_return_functions = {"addprimes", "idealfrobenius", "removeprimes"}
 
 
 class PariFunctionGenerator(object):

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -29,5 +29,18 @@ class TestBackward(unittest.TestCase):
         self.assertEqual(pari('x*y^2 + 1').poldegree(pari('x')), 1)
         self.assertEqual(pari('x*y^2 + 1').poldegree(pari('y')), 2)
 
+    def test_idealfrobenius_after_getitem(self):
+        pari = cypari2.Pari()
+        nf = pari('nfinit(x^2 + 1)')
+        prime = nf.idealfactor(7)[0, 0]
+        gal = nf.galoisinit()
+
+        # Accessing an entry moves gal to the heap. For residue degree 2,
+        # idealfrobenius() returns a reference to an entry of gal.group.
+        _ = gal[5]
+        expected = pari('Vecsmall([2, 1])')
+        self.assertEqual(nf.idealfrobenius(gal, prime), expected)
+        self.assertEqual(pari.idealfrobenius(nf, gal, prime), expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- copy `idealfrobenius` results before wrapping them when PARI returns a borrowed reference
- add regression coverage for both the `Gen` method and `Pari` function entry points

## Root cause

Accessing an entry of the Galois data moves it from the PARI stack to a heap clone. For residue degree 2, PARI returns an entry of `gal.group` directly. That interior pointer is not itself marked as a clone, so cypari2's ordinary `new_gen()` return handling rejects it.

Routing `idealfrobenius` through the existing `gcopy` return path puts an independent copy on the PARI stack before wrapping it.

Fixes #136.

## Validation

- regenerated and compiled the wrappers against PARI 2.17.3
- `PYTHONPATH=build/investigate make check`
  - 2,477 doctests passed
  - 3 integer tests passed
  - 4 backward-compatibility tests passed
