### PR TITLE
Make CyPari2's Python API thread-safe

### DIFF
--- a/.install-pari.sh
+++ b/.install-pari.sh
@@ -117,10 +117,19 @@ if [[ "$PLATFORM" = "msys" ]]; then
   # in Python to find the DLLs.
   CONFIG_ARGS="--without-readline --prefix=$MSYSTEM_PREFIX"
 else
-  CONFIG_ARGS="--prefix=/usr"
+  CONFIG_ARGS="--mt=pthread --prefix=/usr"
 fi
 chmod -R +x ./Configure ./config
 ./Configure $CONFIG_ARGS
+if [[ "$PLATFORM" != "msys" ]]; then
+  PARI_CONFIG_HEADER="$(./config/objdir)/paricfg.h"
+  if ! grep -q '^#define PARI_MT_ENGINE "pthread"$' \
+      "$PARI_CONFIG_HEADER"; then
+    echo "PARI Configure did not select the requested pthread engine"
+    grep 'PARI_MT_ENGINE' "$PARI_CONFIG_HEADER" || true
+    exit 1
+  fi
+fi
 
 # On Windows, disable UNIX-specific code in language files
 # (not sure why UNIX is defined)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ check:
 	ulimit -s 8192; $(PYTHON) -u tests/rundoctest.py
 	ulimit -s 8192; $(PYTHON) tests/test_integers.py
 	ulimit -s 8192; $(PYTHON) tests/test_backward.py
+	ulimit -s 8192; $(PYTHON) tests/test_threading.py
 
 dist:
 	chmod go+rX-w -R .

--- a/autogen/generator.py
+++ b/autogen/generator.py
@@ -151,6 +151,7 @@ class PariFunctionGenerator(object):
             ...     help=r"bnfinit(P,{flag=0},{tech=[]}): compute...",
             ...     **{"class":"basic", "section":"number_fields"})
                 GEN bnfinit0(GEN, long, GEN, long)
+                @_owner_method
                 def bnfinit(P, long flag=0, tech=None, long precision=DEFAULT_BITPREC):
                     ...
                     cdef bint _have_tech = (tech is not None)
@@ -171,6 +172,7 @@ class PariFunctionGenerator(object):
             ...     help=r"ellmodulareqn(N,{x},{y}): return...",
             ...     **{"class":"basic", "section":"elliptic_curves"})
                 GEN ellmodulareqn(long, long, long)
+                @_owner_method
                 def ellmodulareqn(self, long N, x=None, y=None):
                     ...
                     cdef long _x = -1
@@ -189,6 +191,7 @@ class PariFunctionGenerator(object):
             ...     doc=r"reseeds the random number generator...",
             ...     **{"class":"basic", "section":"programming/specific"})
                 void setrand(GEN)
+                @_owner_method
                 def setrand(n):
                     r'''
                     Reseeds the random number generator...
@@ -198,6 +201,7 @@ class PariFunctionGenerator(object):
                     setrand(_n)
                     clear_stack()
             <BLANKLINE>
+                @_owner_method
                 def setrand(self, n):
                     r'''
                     Reseeds the random number generator...
@@ -214,6 +218,7 @@ class PariFunctionGenerator(object):
             ...     obsolete="2008-07-20",
             ...     **{"class":"basic", "section":"number_fields"})
                 GEN polredord(GEN)
+                @_owner_method
                 def polredord(x):
                     r'''
                     This function is obsolete, use polredbest.
@@ -225,6 +230,7 @@ class PariFunctionGenerator(object):
                     cdef GEN _ret = polredord(_x)
                     return new_gen(_ret)
             <BLANKLINE>
+                @_owner_method
                 def polredord(self, x):
                     r'''
                     This function is obsolete, use polredbest.
@@ -313,8 +319,8 @@ class PariFunctionGenerator(object):
 
         protoargs = ", ".join(a.prototype_code() for a in args)
         callargs = ", ".join(a.call_code() for a in cargs)
-
-        s = "    def {function}({protoargs}):\n"
+        s = "    @_owner_method\n"
+        s += "    def {function}({protoargs}):\n"
         if doc:
             # Use triple single quotes to make it easier to doctest
             # this within triply double quoted docstrings.

--- a/cypari2/__init__.py
+++ b/cypari2/__init__.py
@@ -1,6 +1,17 @@
-from .pari_instance import Pari
+from .pari_instance import (Pari, _initialize_pari_owner,
+                            _set_owner_request_active)
 from .handle_error import PariError
-from .gen import Gen
-from .custom_block import init_custom_block
+from .gen import Gen, _stabilize_thread_result
+from .custom_block import init_custom_block, _set_custom_signal_owner
+from ._thread_runtime import runtime as _pari_thread_runtime
+
+
+def _initialize_thread_owner():
+    _set_custom_signal_owner()
+    _initialize_pari_owner()
+
 
 init_custom_block()
+_pari_thread_runtime.install_initializer(_initialize_thread_owner)
+_pari_thread_runtime.install_result_stabilizer(_stabilize_thread_result)
+_pari_thread_runtime.install_request_activity_hook(_set_owner_request_active)

--- a/cypari2/_thread_runtime.py
+++ b/cypari2/_thread_runtime.py
@@ -13,9 +13,11 @@ initialized and cannot introduce an import cycle.
 from __future__ import annotations
 
 import atexit
+import contextvars
 import functools
 import os
 import queue
+import sys
 import threading
 
 
@@ -36,11 +38,11 @@ def owner_method(method):
 class _Request:
     __slots__ = (
         "callable", "args", "kwargs", "done", "result", "exc_info",
-        "stabilize", "activity",
+        "stabilize", "activity", "context",
     )
 
     def __init__(self, callable_, args, kwargs, *, wait=True,
-                 stabilize=True, activity=True):
+                 stabilize=True, activity=True, context=None):
         self.callable = callable_
         self.args = args
         self.kwargs = kwargs
@@ -49,6 +51,7 @@ class _Request:
         self.exc_info = None
         self.stabilize = stabilize
         self.activity = activity
+        self.context = context
 
 
 class _OwnerIterator:
@@ -125,11 +128,29 @@ class _PariThreadRuntime:
                 thread = self._thread
                 if thread is None:
                     self._ready.clear()
-                    thread = threading.Thread(
-                        target=self._run,
-                        name="cypari2-pari-owner",
-                        daemon=True,
-                    )
+                    # Free-threaded Python builds inherit the creating
+                    # thread's Context by default.  The owner is long-lived,
+                    # so inheriting the first caller's context would leak it
+                    # into unrelated later requests.  Start from an empty
+                    # context and enter a fresh caller snapshot per request.
+                    empty_context = contextvars.Context()
+                    if sys.version_info >= (3, 14):
+                        # Passing the Context to Thread also prevents its
+                        # bootstrap code from retaining an inherited creator
+                        # context for the lifetime of the Thread object.
+                        thread = threading.Thread(
+                            target=self._run,
+                            name="cypari2-pari-owner",
+                            daemon=True,
+                            context=empty_context,
+                        )
+                    else:
+                        thread = threading.Thread(
+                            target=empty_context.run,
+                            args=(self._run,),
+                            name="cypari2-pari-owner",
+                            daemon=True,
+                        )
                     self._thread = thread
                     thread.start()
         self._ready.wait()
@@ -141,7 +162,8 @@ class _PariThreadRuntime:
         if self.is_owner():
             return callable_(*args, **kwargs)
         self.ensure_started()
-        request = _Request(callable_, args, kwargs)
+        request = _Request(
+            callable_, args, kwargs, context=contextvars.copy_context())
         # Serialize the final liveness check and enqueue with shutdown's stop
         # marker.  Otherwise a late request could land behind the marker and
         # wait forever after the owner exits.
@@ -212,6 +234,44 @@ class _PariThreadRuntime:
         """Finish callback tracking and return whether PARI reset state."""
         return self._callback_error_stack.pop()
 
+    def _run_request(self, request):
+        """Execute one request inside its submitting Python context."""
+        try:
+            if request.activity:
+                self._request_activity(True)
+            if not self._initialized:
+                if self._initializer is None:
+                    raise RuntimeError("cypari2 runtime is not fully initialized")
+                self._initializer()
+                self._initialized = True
+            request.result = request.callable(*request.args, **request.kwargs)
+        except BaseException as exc:
+            # Preserve the original traceback while transferring the
+            # exception to the submitting thread.
+            request.exc_info = (exc, exc.__traceback__)
+        finally:
+            if self._initialized and request.stabilize:
+                try:
+                    # Also run this after an exception: arbitrary Python
+                    # conversion code may have retained a stack Gen by a
+                    # side effect even though the request has no result.
+                    request.result = self._stabilize(request.result)
+                except BaseException as exc:
+                    if request.exc_info is not None:
+                        exc.__context__ = request.exc_info[0]
+                    request.exc_info = (exc, exc.__traceback__)
+            request.callable = None
+            request.args = None
+            request.kwargs = None
+            if request.activity:
+                try:
+                    self._request_activity(False)
+                except BaseException as exc:
+                    # Never strand a caller if the internal signal hook
+                    # itself fails while a request is being torn down.
+                    if request.exc_info is None:
+                        request.exc_info = (exc, exc.__traceback__)
+
     def _run(self):
         self._owner_ident = threading.get_ident()
         self._ready.set()
@@ -219,43 +279,33 @@ class _PariThreadRuntime:
             request = self._queue.get()
             if request is self._STOP:
                 break
+            context = request.context
             try:
-                if request.activity:
-                    self._request_activity(True)
-                if not self._initialized:
-                    if self._initializer is None:
-                        raise RuntimeError("cypari2 runtime is not fully initialized")
-                    self._initializer()
-                    self._initialized = True
-                request.result = request.callable(*request.args, **request.kwargs)
+                if context is None:
+                    self._run_request(request)
+                else:
+                    context.run(self._run_request, request)
             except BaseException as exc:
-                # Preserve the original traceback while transferring the
-                # exception to the submitting thread.
+                # _run_request normally transfers every failure itself.  Do
+                # the same for failures entering or leaving Context.run so a
+                # waiting caller can never be stranded.
+                if request.exc_info is not None:
+                    exc.__context__ = request.exc_info[0]
                 request.exc_info = (exc, exc.__traceback__)
-            finally:
-                if self._initialized and request.stabilize:
-                    try:
-                        # Also run this after an exception: arbitrary Python
-                        # conversion code may have retained a stack Gen by a
-                        # side effect even though the request has no result.
-                        request.result = self._stabilize(request.result)
-                    except BaseException as exc:
-                        if request.exc_info is not None:
-                            exc.__context__ = request.exc_info[0]
-                        request.exc_info = (exc, exc.__traceback__)
                 request.callable = None
                 request.args = None
                 request.kwargs = None
-                if request.activity:
-                    try:
-                        self._request_activity(False)
-                    except BaseException as exc:
-                        # Never strand a caller if the internal signal hook
-                        # itself fails while a request is being torn down.
-                        if request.exc_info is None:
-                            request.exc_info = (exc, exc.__traceback__)
-                if request.done is not None:
-                    request.done.set()
+            finally:
+                request.context = None
+                # Release the caller's Context before publishing completion.
+                # This makes return from call() a lifetime boundary even on a
+                # free-threaded Python build.
+                context = None
+                done = request.done
+                request = None
+                if done is not None:
+                    done.set()
+                done = None
         self._owner_ident = None
 
     def _after_fork_child(self):

--- a/cypari2/_thread_runtime.py
+++ b/cypari2/_thread_runtime.py
@@ -1,0 +1,298 @@
+"""Thread-affine execution support for libpari.
+
+PARI libraries built with ``--enable-tls`` require every thread entering
+libpari to own an initialized PARI context.  More importantly, a ``GEN`` on
+the PARI stack or clone heap must be managed by the context that created it.
+
+The public cypari2 API therefore uses a single owner thread.  Calls made from
+other Python threads are marshalled to that thread.  This module deliberately
+does not import any Cython extension module, so it can start before libpari is
+initialized and cannot introduce an import cycle.
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import os
+import queue
+import threading
+
+
+def _noop():
+    return None
+
+
+def owner_method(method):
+    """Decorate an extension method so bound and unbound calls dispatch."""
+    @functools.wraps(method)
+    def owner_call(*args, **kwargs):
+        return runtime.call(method, *args, **kwargs)
+
+    owner_call._cypari2_owner_method = True
+    return owner_call
+
+
+class _Request:
+    __slots__ = (
+        "callable", "args", "kwargs", "done", "result", "exc_info",
+        "stabilize", "activity",
+    )
+
+    def __init__(self, callable_, args, kwargs, *, wait=True,
+                 stabilize=True, activity=True):
+        self.callable = callable_
+        self.args = args
+        self.kwargs = kwargs
+        self.done = threading.Event() if wait else None
+        self.result = None
+        self.exc_info = None
+        self.stabilize = stabilize
+        self.activity = activity
+
+
+class _OwnerIterator:
+    """Keep iterator advancement on the PARI owner thread."""
+
+    __slots__ = ("_runtime", "_iterator")
+
+    def __init__(self, runtime, iterator):
+        self._runtime = runtime
+        self._iterator = iterator
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self._runtime.call(next, self._iterator)
+
+
+class _PariThreadRuntime:
+    """Run all direct libpari access on one long-lived thread."""
+
+    _STOP = object()
+
+    def __init__(self):
+        self._start_lock = threading.Lock()
+        # Enqueue bookkeeping can decref a temporary Gen and synchronously
+        # enter Gen.__dealloc__ on the same Python thread.  Its clone release
+        # submits another owner request, so this lock must be re-entrant.
+        self._queue_lock = threading.RLock()
+        self._queue = queue.SimpleQueue()
+        self._thread = None
+        self._owner_ident = None
+        self._ready = threading.Event()
+        self._initializer = None
+        self._initialized = False
+        self._stabilize = lambda value: value
+        self._request_activity = lambda active: None
+        self._callback_error_stack = []
+        self._forked_with_owner = False
+        self._shutting_down = False
+        if hasattr(os, "register_at_fork"):
+            os.register_at_fork(after_in_child=self._after_fork_child)
+
+    def install_result_stabilizer(self, stabilizer):
+        """Install the owner-side hook that detaches results from the stack."""
+        self._stabilize = stabilizer
+
+    def install_initializer(self, initializer):
+        """Install the function which initializes libpari on the owner."""
+        self._initializer = initializer
+
+    def install_request_activity_hook(self, hook):
+        """Install the hook used by the asynchronous signal router."""
+        self._request_activity = hook
+
+    def is_owner(self):
+        """Return whether the current OS thread owns the PARI context."""
+        return threading.get_ident() == self._owner_ident
+
+    def ensure_started(self):
+        """Start the owner thread, once, before initializing libpari."""
+        if self._shutting_down:
+            raise RuntimeError("the cypari2 PARI owner thread is shutting down")
+        if self._forked_with_owner:
+            raise RuntimeError(
+                "cypari2 was initialized before fork; use the multiprocessing "
+                "'spawn' start method in the child process"
+            )
+        thread = self._thread
+        if thread is None:
+            with self._start_lock:
+                if self._shutting_down:
+                    raise RuntimeError("the cypari2 PARI owner thread is shutting down")
+                thread = self._thread
+                if thread is None:
+                    self._ready.clear()
+                    thread = threading.Thread(
+                        target=self._run,
+                        name="cypari2-pari-owner",
+                        daemon=True,
+                    )
+                    self._thread = thread
+                    thread.start()
+        self._ready.wait()
+        if not thread.is_alive():
+            raise RuntimeError("the cypari2 PARI owner thread is no longer available")
+
+    def call(self, callable_, *args, **kwargs):
+        """Run ``callable_`` on the owner and return or re-raise its result."""
+        if self.is_owner():
+            return callable_(*args, **kwargs)
+        self.ensure_started()
+        request = _Request(callable_, args, kwargs)
+        # Serialize the final liveness check and enqueue with shutdown's stop
+        # marker.  Otherwise a late request could land behind the marker and
+        # wait forever after the owner exits.
+        with self._queue_lock:
+            if self._shutting_down or not self._thread.is_alive():
+                raise RuntimeError("the cypari2 PARI owner thread is no longer available")
+            self._queue.put(request)
+        request.done.wait()
+        if request.exc_info is not None:
+            exc, traceback = request.exc_info
+            raise exc.with_traceback(traceback)
+        return request.result
+
+    def ensure_initialized(self):
+        """Ensure that the owner has initialized libpari."""
+        if self.is_owner():
+            return
+        self.call(_noop)
+
+    def submit(self, callable_, *args, **kwargs):
+        """Queue best-effort owner work without waiting for it.
+
+        This is used by ``Gen.__dealloc__``.  Failure during interpreter
+        shutdown intentionally leaks the clone instead of freeing it from the
+        wrong PARI context.
+        """
+        if self.is_owner():
+            callable_(*args, **kwargs)
+            return True
+        with self._queue_lock:
+            if (self._shutting_down or self._thread is None or
+                    not self._thread.is_alive()):
+                return False
+            # Clone release neither returns stack data nor executes a
+            # long-running interruptible PARI operation.  Treating every
+            # release as a full public request would repeatedly stabilize an
+            # already-empty stack and can create a large shutdown backlog.
+            self._queue.put(_Request(
+                callable_, args, kwargs,
+                wait=False, stabilize=False, activity=False,
+            ))
+        return True
+
+    def call_type_method(self, cls, name, args, kwargs=None):
+        """Invoke a special method whose lookup bypasses ``__getattribute__``."""
+        if kwargs is None:
+            kwargs = {}
+        return self.call(getattr(cls, name), *args, **kwargs)
+
+    def protect_iterator(self, iterator):
+        """Return an iterator whose advancement is confined to the owner."""
+        return _OwnerIterator(self, iterator)
+
+    def enter_python_callback(self):
+        """Start tracking PARI evaluator errors in a Python callback."""
+        self._callback_error_stack.append(False)
+
+    def note_callback_pari_error(self):
+        """Record that PARI reset the evaluator enclosing callbacks."""
+        for index in range(len(self._callback_error_stack)):
+            self._callback_error_stack[index] = True
+
+    def callback_pari_error_seen(self):
+        """Return whether the innermost active callback lost PARI state."""
+        return bool(self._callback_error_stack[-1])
+
+    def leave_python_callback(self):
+        """Finish callback tracking and return whether PARI reset state."""
+        return self._callback_error_stack.pop()
+
+    def _run(self):
+        self._owner_ident = threading.get_ident()
+        self._ready.set()
+        while True:
+            request = self._queue.get()
+            if request is self._STOP:
+                break
+            try:
+                if request.activity:
+                    self._request_activity(True)
+                if not self._initialized:
+                    if self._initializer is None:
+                        raise RuntimeError("cypari2 runtime is not fully initialized")
+                    self._initializer()
+                    self._initialized = True
+                request.result = request.callable(*request.args, **request.kwargs)
+            except BaseException as exc:
+                # Preserve the original traceback while transferring the
+                # exception to the submitting thread.
+                request.exc_info = (exc, exc.__traceback__)
+            finally:
+                if self._initialized and request.stabilize:
+                    try:
+                        # Also run this after an exception: arbitrary Python
+                        # conversion code may have retained a stack Gen by a
+                        # side effect even though the request has no result.
+                        request.result = self._stabilize(request.result)
+                    except BaseException as exc:
+                        if request.exc_info is not None:
+                            exc.__context__ = request.exc_info[0]
+                        request.exc_info = (exc, exc.__traceback__)
+                request.callable = None
+                request.args = None
+                request.kwargs = None
+                if request.activity:
+                    try:
+                        self._request_activity(False)
+                    except BaseException as exc:
+                        # Never strand a caller if the internal signal hook
+                        # itself fails while a request is being torn down.
+                        if request.exc_info is None:
+                            request.exc_info = (exc, exc.__traceback__)
+                if request.done is not None:
+                    request.done.set()
+        self._owner_ident = None
+
+    def _after_fork_child(self):
+        had_owner = self._thread is not None
+        try:
+            self._request_activity(False)
+        except Exception:
+            pass
+        self._thread = None
+        self._owner_ident = None
+        self._initialized = False
+        self._callback_error_stack = []
+        self._queue = queue.SimpleQueue()
+        self._start_lock = threading.Lock()
+        self._queue_lock = threading.RLock()
+        self._ready = threading.Event()
+        self._forked_with_owner = had_owner
+        self._shutting_down = False
+
+    def shutdown(self):
+        """Drain queued work and stop the daemon thread at interpreter exit."""
+        if self.is_owner():
+            return
+        with self._start_lock:
+            with self._queue_lock:
+                if self._shutting_down:
+                    return
+                self._shutting_down = True
+                thread = self._thread
+                if thread is None or not thread.is_alive():
+                    return
+                self._queue.put(self._STOP)
+        # Do not let Python tear extension modules down while a request still
+        # executes C code on the owner.  Normal shutdown is immediate because
+        # the stop marker follows all already-queued work.
+        thread.join()
+
+
+runtime = _PariThreadRuntime()
+atexit.register(runtime.shutdown)

--- a/cypari2/closure.pyx
+++ b/cypari2/closure.pyx
@@ -31,15 +31,19 @@ Examples:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from cysignals.signals cimport sig_on, sig_off, sig_block, sig_unblock, sig_error
+from cysignals.signals cimport sig_on, sig_off, sig_block, sig_unblock
 
 from cpython.tuple cimport *
 from cpython.object cimport PyObject_Call
 from cpython.ref cimport Py_INCREF
 
 from .paridecl cimport *
-from .stack cimport new_gen, new_gen_noclear, clone_gen_noclear, DetachGen
+from .stack cimport (new_gen, new_gen_noclear, clone_gen_noclear, DetachGen,
+                     move_gens_above_to_heap)
 from .gen cimport objtogen
+from ._thread_runtime import runtime as _pari_thread_runtime
+from .thread_support cimport (sig_error_local, callback_signal_push,
+                              callback_signal_pop)
 
 try:
     from inspect import getfullargspec as getargspec
@@ -55,8 +59,15 @@ cdef inline GEN call_python_func_impl "call_python_func"(GEN* args, object py_fu
     The arguments are converted from ``GEN`` to a cypari ``gen`` before
     calling ``py_func``. The result is converted back to a PARI ``GEN``.
     """
-    # We need to ensure that nothing above avma is touched
-    avmaguard = new_gen_noclear(<GEN>avma)
+    # We need to ensure that nothing above avma is touched.  When all
+    # externally visible Gens have already been moved to the heap, avma can
+    # equal pari_mainstack.top.  That address is the first byte *outside* the
+    # stack and cannot be wrapped as a synthetic Gen, so allocate a minimal
+    # real stack object for the guard in that case.
+    cdef GEN guard = <GEN>avma
+    if avma == pari_mainstack.top:
+        guard = cgetg(1, t_VEC)
+    avmaguard = new_gen_noclear(guard)
 
     # How many arguments are there?
     cdef Py_ssize_t n = 0
@@ -71,21 +82,55 @@ cdef inline GEN call_python_func_impl "call_python_func"(GEN* args, object py_fu
         Py_INCREF(a)  # Need to increase refcount because the tuple steals it
         PyTuple_SET_ITEM(t, i, a)
 
-    # Call the Python function
-    r = PyObject_Call(py_func, t, <dict>NULL)
+    # Call the Python function.  Give PARI operations made by the callback a
+    # nested cysignals jump target, so their errors return through Python
+    # normally instead of jumping across the callback's Python frames.
+    cdef void *signal_state = NULL
+    cdef bint callback_had_pari_error = False
+    cdef GEN res = gnil
+    converted = None
+    _pari_thread_runtime.enter_python_callback()
+    try:
+        signal_state = callback_signal_push()
+        try:
+            r = PyObject_Call(py_func, t, <dict>NULL)
+            if _pari_thread_runtime.callback_pari_error_seen():
+                raise RuntimeError(
+                    "a PARI error cannot be caught and suppressed inside a "
+                    "Python callback; the enclosing PARI evaluation was aborted"
+                )
+            if r is not None:
+                converted = objtogen(r)
+                if _pari_thread_runtime.callback_pari_error_seen():
+                    raise RuntimeError(
+                        "a PARI error cannot be caught and suppressed while "
+                        "converting a Python callback result; the enclosing "
+                        "PARI evaluation was aborted"
+                    )
+        finally:
+            # A callback or its result conversion can retain a Gen through a
+            # side effect instead of returning it.  Clone every stack Gen
+            # created since the guard while the nested signal target is
+            # still active.
+            move_gens_above_to_heap(avmaguard)
 
-    # Convert the result to a GEN and copy it to the PARI stack
-    # (with a special case for None)
-    if r is None:
-        return gnil
+        if r is not None:
+            d = DetachGen(converted)
+            del converted
+            del r
+            res = d.detach()
+        d = DetachGen(avmaguard)
+        del avmaguard
+        d.detach()
+    finally:
+        callback_signal_pop(signal_state)
+        callback_had_pari_error = _pari_thread_runtime.leave_python_callback()
 
-    # Safely delete r and avmaguard
-    d = DetachGen(objtogen(r))
-    del r
-    res = d.detach()
-    d = DetachGen(avmaguard)
-    del avmaguard
-    d.detach()
+    if callback_had_pari_error:
+        raise RuntimeError(
+            "a PARI error cannot be caught and suppressed inside a Python "
+            "callback; the enclosing PARI evaluation was aborted"
+        )
 
     return res
 
@@ -94,7 +139,42 @@ cdef inline GEN call_python_func_impl "call_python_func"(GEN* args, object py_fu
 # signature. In particular, we want manual exception handling and we
 # implicitly convert py_func from a PyObject* to an object.
 cdef extern from *:
+    """
+    #ifndef _WIN32
+    #include <pthread.h>
+    static pthread_t cypari2_python_callback_owner;
+    static int cypari2_python_callback_owner_ready;
+
+    static void cypari2_set_python_callback_owner(void)
+    {
+        cypari2_python_callback_owner = pthread_self();
+        cypari2_python_callback_owner_ready = 1;
+    }
+
+    static int cypari2_python_callback_on_owner(void)
+    {
+        return cypari2_python_callback_owner_ready &&
+               pthread_equal(pthread_self(), cypari2_python_callback_owner);
+    }
+    #else
+    #include <windows.h>
+    static DWORD cypari2_python_callback_owner;
+    static int cypari2_python_callback_owner_ready;
+    static void cypari2_set_python_callback_owner(void)
+    {
+        cypari2_python_callback_owner = GetCurrentThreadId();
+        cypari2_python_callback_owner_ready = 1;
+    }
+    static int cypari2_python_callback_on_owner(void)
+    {
+        return cypari2_python_callback_owner_ready &&
+               GetCurrentThreadId() == cypari2_python_callback_owner;
+    }
+    #endif
+    """
     GEN call_python_func(GEN* args, PyObject* py_func)
+    void cypari2_set_python_callback_owner() noexcept nogil
+    int cypari2_python_callback_on_owner() noexcept nogil
 
 
 cdef GEN call_python(GEN arg1, GEN arg2, GEN arg3, GEN arg4, GEN arg5,
@@ -107,8 +187,17 @@ cdef GEN call_python(GEN arg1, GEN arg2, GEN arg3, GEN arg4, GEN arg5,
     specifying how many arguments are valid and one ``ulong``, which is
     actually a Python callable object cast to ``ulong``.
     """
+    # PARI's pthread workers do not own the Python GIL and cannot safely
+    # enter this callback.  Report the condition through PARI's worker error
+    # channel without touching the Python C API.  Users can still use a
+    # Python callback with parallel APIs after setting ``nbthreads`` to 1;
+    # native PARI closures remain fully parallel.
+    if not cypari2_python_callback_on_owner():
+        pari_err(e_MISC, "Python callbacks cannot run in PARI worker threads; set nbthreads to 1")
+        return NULL
+
     if nargs > 5:
-        sig_error()
+        sig_error_local()
 
     # Convert arguments to a NULL-terminated array.
     cdef GEN args[6]
@@ -127,7 +216,7 @@ cdef GEN call_python(GEN arg1, GEN arg2, GEN arg3, GEN arg4, GEN arg5,
     cdef GEN r = call_python_func(args, <PyObject*>py_func)
     sig_unblock()
     if not r:  # An exception was raised
-        sig_error()
+        sig_error_local()
     return r
 
 
@@ -138,6 +227,7 @@ cdef int _pari_init_closure() except -1:
     sig_on()
     global ep_call_python
     ep_call_python = install(<void*>call_python, "call_python", 'DGDGDGDGDGD5,U,U')
+    cypari2_set_python_callback_owner()
     sig_off()
 
 
@@ -209,6 +299,9 @@ cpdef Gen objtoclosure(f):
     ...
     PariError: call_python: ...
     """
+    if not _pari_thread_runtime.is_owner():
+        return _pari_thread_runtime.call(objtoclosure, f)
+
     if not callable(f):
         raise TypeError("argument to objtoclosure() must be callable")
 

--- a/cypari2/convert.pyx
+++ b/cypari2/convert.pyx
@@ -39,7 +39,7 @@ some bit shuffling.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from cysignals.signals cimport sig_on, sig_off, sig_error
+from cysignals.signals cimport sig_on, sig_off
 
 from cpython.version cimport PY_MAJOR_VERSION
 from cpython.long cimport PyLong_AsLong, PyLong_FromLong
@@ -53,6 +53,8 @@ from .stack cimport new_gen, reset_avma
 from .string_utils cimport to_string, to_bytes
 from .pycore_long cimport (ob_digit, _PyLong_IsZero, _PyLong_IsPositive,
                            _PyLong_DigitCount, _PyLong_SetSignAndDigitCount)
+from ._thread_runtime import runtime as _pari_thread_runtime
+from .thread_support cimport sig_error_local
 
 ########################################################################
 # Conversion PARI -> Python
@@ -221,6 +223,8 @@ cpdef gen_to_python(Gen z):
     ...
     NotImplementedError: conversion not implemented for t_PADIC
     """
+    if not _pari_thread_runtime.is_owner():
+        return _pari_thread_runtime.call(gen_to_python, z)
     return PyObject_FromGEN(z.g)
 
 
@@ -299,6 +303,8 @@ cpdef gen_to_integer(Gen x):
     ...             if type(N1) is not type(N2):
     ...                 print(N1, type(N1), N2, type(N2))
     """
+    if not _pari_thread_runtime.is_owner():
+        return _pari_thread_runtime.call(gen_to_integer, x)
     return PyInt_FromGEN(x.g)
 
 
@@ -394,7 +400,7 @@ cdef GEN gtoi(GEN g0) except NULL:
             g = gel(g, 2)
         g = trunc_safe(g)
         if typ(g) != t_INT:
-            sig_error()
+            sig_error_local()
         sig_off()
     except RuntimeError:
         s = to_string(stack_sprintf(
@@ -605,6 +611,8 @@ def integer_to_gen(x):
     ...     if pari(long(x)) != pari(x) or pari(int(x)) != pari(x):
     ...         print(x)
     """
+    if not _pari_thread_runtime.is_owner():
+        return _pari_thread_runtime.call(integer_to_gen, x)
     if isinstance(x, int):
         sig_on()
         return new_gen(PyLong_AS_GEN(x))

--- a/cypari2/custom_block.pyx
+++ b/cypari2/custom_block.pyx
@@ -11,15 +11,57 @@ from .stack cimport reset_avma
 cdef extern from "pari/pari.h":
     int     PARI_SIGINT_block, PARI_SIGINT_pending
 
+cdef extern from *:
+    """
+    #ifndef _WIN32
+    #include <pthread.h>
+    static pthread_t cypari2_custom_signal_owner;
+    static int cypari2_custom_signal_owner_ready;
+    static void cypari2_set_custom_signal_owner(void)
+    {
+        cypari2_custom_signal_owner = pthread_self();
+        cypari2_custom_signal_owner_ready = 1;
+    }
+    static int cypari2_custom_signal_on_owner(void)
+    {
+        return cypari2_custom_signal_owner_ready &&
+               pthread_equal(pthread_self(), cypari2_custom_signal_owner);
+    }
+    #else
+    #include <windows.h>
+    static DWORD cypari2_custom_signal_owner;
+    static int cypari2_custom_signal_owner_ready;
+    static void cypari2_set_custom_signal_owner(void)
+    {
+        cypari2_custom_signal_owner = GetCurrentThreadId();
+        cypari2_custom_signal_owner_ready = 1;
+    }
+    static int cypari2_custom_signal_on_owner(void)
+    {
+        return cypari2_custom_signal_owner_ready &&
+               GetCurrentThreadId() == cypari2_custom_signal_owner;
+    }
+    #endif
+    """
+    void cypari2_set_custom_signal_owner() noexcept nogil
+    int cypari2_custom_signal_on_owner() noexcept nogil
+
+
 cdef int custom_signal_is_blocked() noexcept:
+    if not cypari2_custom_signal_on_owner():
+        return 0
     return PARI_SIGINT_block
 
 cdef void custom_signal_unblock() noexcept:
+    if not cypari2_custom_signal_on_owner():
+        return
     global PARI_SIGINT_block
     PARI_SIGINT_block = 0
     reset_avma()
 
 cdef void custom_set_pending_signal(int sig) noexcept:
+    if not cypari2_custom_signal_on_owner():
+        return
     global PARI_SIGINT_pending
     PARI_SIGINT_pending = sig
 
@@ -27,3 +69,8 @@ def init_custom_block():
     add_custom_signals(&custom_signal_is_blocked,
                        &custom_signal_unblock,
                        &custom_set_pending_signal)
+
+
+def _set_custom_signal_owner():
+    """Bind PARI-aware cysignals hooks to the permanent owner thread."""
+    cypari2_set_custom_signal_owner()

--- a/cypari2/gen.pyx
+++ b/cypari2/gen.pyx
@@ -56,8 +56,10 @@ AUTHORS:
 # ****************************************************************************
 
 cimport cython
+import operator as _operator
 
-from cpython.object cimport (Py_EQ, Py_NE, Py_LE, Py_GE, Py_LT, PyTypeObject)
+from cpython.object cimport (Py_EQ, Py_NE, Py_LE, Py_GE, Py_LT, Py_GT,
+                            PyTypeObject)
 
 from cysignals.memory cimport sig_free, check_malloc
 from cysignals.signals cimport sig_check, sig_on, sig_off, sig_block, sig_unblock
@@ -71,6 +73,8 @@ from .stack cimport (new_gen, new_gens2, new_gen_noclear,
                      clone_gen, clear_stack, reset_avma,
                      remove_from_pari_stack, move_gens_to_heap)
 from .closure cimport objtoclosure
+from ._thread_runtime import (owner_method as _owner_method,
+                              runtime as _pari_thread_runtime)
 
 from .paridecl cimport *
 
@@ -146,10 +150,10 @@ cdef class Gen(Gen_base):
     Wrapper for a PARI ``GEN`` with memory management.
 
     This wraps PARI objects which live either on the PARI stack or on
-    the PARI heap. Results from PARI computations appear on the PARI
-    stack and we try to keep them there. However, when the stack fills
-    up, we copy ("clone" in PARI speak) all live objects from the stack
-    to the heap. This happens transparently for the user.
+    the PARI heap. Results may live on the stack while an owner-thread
+    request is running. Before control returns to another Python thread,
+    all live stack objects are copied ("cloned" in PARI speak) to the
+    heap. This happens transparently for the user.
     """
     def __init__(self):
         raise RuntimeError("PARI objects cannot be instantiated directly; use pari(x) to convert x to PARI")
@@ -160,7 +164,21 @@ cdef class Gen(Gen_base):
             remove_from_pari_stack(self)
         elif self.address is not NULL:
             # clone
-            gunclone_deep(self.address)
+            if _pari_thread_runtime.is_owner():
+                gunclone_deep(self.address)
+            else:
+                # Clone bookkeeping is thread-local in a pthread build of
+                # PARI.  Hand the raw address back to the context which
+                # created it.  Clear it first so this object cannot free it
+                # twice if shutdown code re-enters Python.
+                address = <size_t>self.address
+                self.address = NULL
+                try:
+                    _pari_thread_runtime.submit(_free_owner_clone, address)
+                except Exception:
+                    # During interpreter shutdown leaking is safer than
+                    # touching another thread's PARI clone registry.
+                    pass
 
     cdef Gen new_ref(self, GEN g):
         """
@@ -237,6 +255,9 @@ cdef class Gen(Gen_base):
         >>> pari('Str(hello)')
         "hello"
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__repr__", (self,))
+
         cdef char *c
         sig_on()
         # Use sig_block(), which is needed because GENtostr() uses
@@ -270,6 +291,9 @@ cdef class Gen(Gen_base):
         >>> str(pari('Str(hello)'))
         'hello'
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__str__", (self,))
+
         # Use __repr__ except for strings
         if typ(self.g) == t_STR:
             return to_string(GSTR(self.g))
@@ -291,6 +315,9 @@ cdef class Gen(Gen_base):
         >>> hash(pari.isprime(4)) == hash(pari(0))
         True
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__hash__", (self,))
+
         # There is a bug in PARI/GP where the hash value depends on the
         # CLONE bit. So we remove that bit before hashing. See
         # https://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=2091
@@ -325,8 +352,9 @@ cdef class Gen(Gen_base):
         >>> from cypari2 import Pari
         >>> pari = Pari()
         >>> L = pari("vector(10,i,i^2)")
-        >>> L.__iter__()
-        <...generator object at ...>
+        >>> iterator = iter(L)
+        >>> next(iterator)
+        1
         >>> [x for x in L]
         [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
         >>> list(L)
@@ -388,6 +416,10 @@ cdef class Gen(Gen_base):
         >>> list(v)
         ['h', 'e', 'l', 'l', 'o']
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(
+                Gen, "__iter__", (self,))
+
         # We return a generator expression instead of using "yield"
         # because we want to raise an exception for non-iterable
         # objects immediately when calling __iter__() and not while
@@ -406,17 +438,26 @@ cdef class Gen(Gen_base):
             raise TypeError(f"PARI object of type {self.type()} is not iterable")
         elif t == t_VECSMALL:
             # Special case: items of type int
-            return (self.g[i] for i in range(1, lg(self.g)))
+            return _pari_thread_runtime.protect_iterator(
+                (self[i] for i in range(len(self))))
         elif t == t_STR:
             # Special case: convert to str
-            return iter(to_string(GSTR(self.g)))
+            return _pari_thread_runtime.protect_iterator(
+                iter(to_string(GSTR(self.g))))
         else:
             v = self.Vec()
 
-        # Now iterate over the vector v
+        # Keep the iterator itself behind a proxy: a Python callback runs on
+        # the owner and can retain iter(self) as a side effect.  If that
+        # iterator later escapes to another Python thread, advancing the raw
+        # Cython generator there would dereference owner-owned GEN pointers.
+        # fixGEN() makes x stable before the generator is created, while the
+        # proxy confines every subsequent new_ref() call to the owner.
         x = v.fixGEN()
-        return (v.new_ref(gel(x, i)) for i in range(1, lg(x)))
+        return _pari_thread_runtime.protect_iterator(
+            (v.new_ref(gel(x, i)) for i in range(1, lg(x))))
 
+    @_owner_method
     def list(self):
         """
         Convert ``self`` to a Python list with :class:`Gen` components.
@@ -473,6 +514,9 @@ cdef class Gen(Gen_base):
         >>> loads(dumps(f)) == f
         True
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__reduce__", (self,))
+
         s = repr(self)
         return (objtogen, (s,))
 
@@ -494,6 +538,9 @@ cdef class Gen(Gen_base):
         >>> -2 + pari(3)
         1
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.add, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -521,6 +568,9 @@ cdef class Gen(Gen_base):
         >>> -2 - pari(3)
         -5
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.sub, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -531,6 +581,9 @@ cdef class Gen(Gen_base):
         return new_gen(gsub(t0.g, t1.g))
 
     def __mul__(left, right):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.mul, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -541,6 +594,9 @@ cdef class Gen(Gen_base):
         return new_gen(gmul(t0.g, t1.g))
 
     def __div__(left, right):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.truediv, left, right)
+
         # Python 2 old-style division: same implementation as __truediv__
         cdef Gen t0, t1
         try:
@@ -561,6 +617,9 @@ cdef class Gen(Gen_base):
         >>> pari("x^2 + 2*x + 3") / pari("x")
         (x^2 + 2*x + 3)/x
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.truediv, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -580,6 +639,9 @@ cdef class Gen(Gen_base):
         >>> pari("x^2 + 2*x + 3") // pari("x")
         x + 2
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.floordiv, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -607,6 +669,9 @@ cdef class Gen(Gen_base):
         >>> -2 % pari(3)
         1
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.mod, left, right)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -637,6 +702,9 @@ cdef class Gen(Gen_base):
         >>> pari(2) ** -5
         1/32
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(pow, left, right, m)
+
         cdef Gen t0, t1
         try:
             t0 = objtogen(left)
@@ -649,6 +717,9 @@ cdef class Gen(Gen_base):
         return new_gen(gpow(t0.g, t1.g, nbits2prec(DEFAULT_BITPREC)))
 
     def __neg__(self):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__neg__", (self,))
+
         sig_on()
         return new_gen(gneg(self.g))
 
@@ -673,6 +744,9 @@ cdef class Gen(Gen_base):
         >>> 33 >> pari(2)
         8
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.rshift, self, n)
+
         cdef Gen t0 = objtogen(self)
         sig_on()
         return new_gen(gshift(t0.g, -n))
@@ -697,14 +771,21 @@ cdef class Gen(Gen_base):
         >>> 33 << pari(2)
         132
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call(_operator.lshift, self, n)
+
         cdef Gen t0 = objtogen(self)
         sig_on()
         return new_gen(gshift(t0.g, n))
 
     def __invert__(self):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__invert__", (self,))
+
         sig_on()
         return new_gen(ginv(self.g))
 
+    @_owner_method
     def getattr(self, attr):
         """
         Return the PARI attribute with the given name.
@@ -734,6 +815,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(closure_callgen1(strtofunction(t), self.g))
 
+    @_owner_method
     def mod(self):
         """
         Given an INTMOD or POLMOD ``Mod(a,m)``, return the modulus `m`.
@@ -761,6 +843,7 @@ cdef class Gen(Gen_base):
 
     # Special case: SageMath uses polred(), so mark it as not
     # obsolete: https://trac.sagemath.org/ticket/22165
+    @_owner_method
     def polred(self, *args, **kwds):
         r'''
         This function is :emphasis:`deprecated`,
@@ -771,6 +854,7 @@ cdef class Gen(Gen_base):
             warnings.simplefilter("ignore")
             return super(Gen, self).polred(*args, **kwds)
 
+    @_owner_method
     def nf_get_pol(self):
         """
         Returns the defining polynomial of this number field.
@@ -809,6 +893,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_pol(self.g))
 
+    @_owner_method
     def nf_get_diff(self):
         """
         Returns the different of this number field as a PARI ideal.
@@ -831,6 +916,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_diff(self.g))
 
+    @_owner_method
     def nf_get_sign(self):
         """
         Returns a Python list ``[r1, r2]``, where ``r1`` and ``r2`` are
@@ -867,6 +953,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return [r1, r2]
 
+    @_owner_method
     def nf_get_zk(self):
         r"""
         Returns a vector with a `\ZZ`-basis for the ring of integers of
@@ -890,6 +977,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_zk(self.g))
 
+    @_owner_method
     def bnf_get_fu(self):
         """
         Return the fundamental units
@@ -913,6 +1001,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_fu(self.g))
 
+    @_owner_method
     def bnf_get_tu(self):
         r"""
         Return the torsion unit
@@ -936,6 +1025,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_tu(self.g))
 
+    @_owner_method
     def bnfunit(self):
         r"""
         Deprecated in cypari 2.1.2
@@ -962,6 +1052,7 @@ cdef class Gen(Gen_base):
         warn("'bnfunit' in cypari2 is deprecated, use 'bnf_get_fu'", DeprecationWarning)
         return self.bnf_get_fu()
 
+    @_owner_method
     def bnf_get_no(self):
         """
         Returns the class number of ``self``, a "big number field" (``bnf``).
@@ -979,6 +1070,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(bnf_get_no(self.g))
 
+    @_owner_method
     def bnf_get_cyc(self):
         """
         Returns the structure of the class group of this number field as
@@ -999,6 +1091,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(bnf_get_cyc(self.g))
 
+    @_owner_method
     def bnf_get_gen(self):
         """
         Returns a vector of generators of the class group of this
@@ -1019,6 +1112,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(bnf_get_gen(self.g))
 
+    @_owner_method
     def bnf_get_reg(self):
         """
         Returns the regulator of this number field.
@@ -1038,6 +1132,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(bnf_get_reg(self.g))
 
+    @_owner_method
     def idealmoddivisor(self, Gen ideal):
         """
         Return a 'small' ideal equivalent to ``ideal`` in the
@@ -1072,6 +1167,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(idealmoddivisor(self.g, ideal.g))
 
+    @_owner_method
     def pr_get_p(self):
         r"""
         Returns the prime of `\ZZ` lying below this prime ideal.
@@ -1094,6 +1190,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(pr_get_p(self.g))
 
+    @_owner_method
     def pr_get_e(self):
         r"""
         Returns the ramification index (over `\QQ`) of this prime ideal.
@@ -1121,6 +1218,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return e
 
+    @_owner_method
     def pr_get_f(self):
         r"""
         Returns the residue class degree (over `\QQ`) of this prime ideal.
@@ -1148,6 +1246,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return f
 
+    @_owner_method
     def pr_get_gen(self):
         """
         Returns the second generator of this PARI prime ideal, where the
@@ -1173,6 +1272,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(pr_get_gen(self.g))
 
+    @_owner_method
     def bid_get_cyc(self):
         """
         Returns the structure of the group `(O_K/I)^*`, where `I` is the
@@ -1195,6 +1295,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(bid_get_cyc(self.g))
 
+    @_owner_method
     def bid_get_gen(self):
         """
         Returns a vector of generators of the group `(O_K/I)^*`, where
@@ -1322,6 +1423,9 @@ cdef class Gen(Gen_base):
         >>> pari([])[::]
         []
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__getitem__", (self, n))
+
         cdef Py_ssize_t i, j, k
         cdef object ind
         cdef int pari_type
@@ -1514,6 +1618,10 @@ cdef class Gen(Gen_base):
         >>> type(v[0])
         <... 'cypari2.gen.Gen'>
         """
+        if not _pari_thread_runtime.is_owner():
+            _pari_thread_runtime.call_type_method(Gen, "__setitem__", (self, n, y))
+            return
+
         cdef Py_ssize_t i, j
         cdef Gen x = objtogen(y)
 
@@ -1573,6 +1681,9 @@ cdef class Gen(Gen_base):
             set_gel(self.g, i+1, xt)
 
     def __len__(self):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__len__", (self,))
+
         return glength(self.g)
 
     def __richcmp__(self, right, int op):
@@ -1638,6 +1749,19 @@ cdef class Gen(Gen_base):
         >>> pari('O(2)') == 0
         True
         """
+        if not _pari_thread_runtime.is_owner():
+            if op == Py_LT:
+                return _pari_thread_runtime.call(_operator.lt, self, right)
+            if op == Py_LE:
+                return _pari_thread_runtime.call(_operator.le, self, right)
+            if op == Py_EQ:
+                return _pari_thread_runtime.call(_operator.eq, self, right)
+            if op == Py_NE:
+                return _pari_thread_runtime.call(_operator.ne, self, right)
+            if op == Py_GT:
+                return _pari_thread_runtime.call(_operator.gt, self, right)
+            return _pari_thread_runtime.call(_operator.ge, self, right)
+
         cdef Gen t1
         try:
             t1 = objtogen(right)
@@ -1662,6 +1786,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return r
 
+    @_owner_method
     def cmp(self, right):
         """
         Compare ``self`` and ``right``.
@@ -1714,6 +1839,9 @@ cdef class Gen(Gen_base):
         return r
 
     def __copy__(self):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__copy__", (self,))
+
         sig_on()
         return clone_gen(self.g)
 
@@ -1721,6 +1849,9 @@ cdef class Gen(Gen_base):
         """
         Return the octal digits of self in lower case.
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__oct__", (self,))
+
         cdef GEN x
         cdef long lx
         cdef long *xp
@@ -1764,6 +1895,9 @@ cdef class Gen(Gen_base):
         """
         Return the hexadecimal digits of self in lower case.
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__hex__", (self,))
+
         cdef GEN x
         cdef long lx
         cdef long *xp
@@ -1841,6 +1975,9 @@ cdef class Gen(Gen_base):
         >>> int(pari(2**63+2)) == 9223372036854775810
         True
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__int__", (self,))
+
         return gen_to_integer(self)
 
     def __index__(self):
@@ -1875,10 +2012,14 @@ cdef class Gen(Gen_base):
         ...     assert hex(pari(i)) == hex(i)
         ...     assert hex(pari(-i)) == hex(-i)
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__index__", (self,))
+
         if typ(self.g) != t_INT:
             raise TypeError(f"cannot coerce {self!r} (type {self.type()}) to integer")
         return gen_to_integer(self)
 
+    @_owner_method
     def python_list_small(self):
         """
         Return a Python list of the PARI gens. This object must be of type
@@ -1901,6 +2042,7 @@ cdef class Gen(Gen_base):
             raise TypeError("Object (=%s) must be of type t_VECSMALL." % self)
         return [self.g[n+1] for n in range(glength(self.g))]
 
+    @_owner_method
     def python_list(self):
         """
         Return a Python list of the PARI gens. This object must be of type
@@ -1938,6 +2080,7 @@ cdef class Gen(Gen_base):
             raise TypeError("Object (=%s) must be of type t_VEC or t_COL." % self)
         return [self[n] for n in range(glength(self.g))]
 
+    @_owner_method
     def python(self):
         """
         Return the closest Python equivalent of the given PARI object.
@@ -1957,6 +2100,7 @@ cdef class Gen(Gen_base):
         from .convert import gen_to_python
         return gen_to_python(self)
 
+    @_owner_method
     def sage(self, locals=None):
         r"""
         Return the closest SageMath equivalent of the given PARI object.
@@ -1975,6 +2119,9 @@ cdef class Gen(Gen_base):
         """
         Return Python float.
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__float__", (self,))
+
         cdef double d
         sig_on()
         d = gtodouble(self.g)
@@ -2016,6 +2163,9 @@ cdef class Gen(Gen_base):
         ...
         PariError: incorrect type in gtofp (t_INTMOD)
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__complex__", (self,))
+
         cdef double re, im
         sig_on()
         # First convert to floating point (t_REAL or t_COMPLEX)
@@ -2050,8 +2200,12 @@ cdef class Gen(Gen_base):
         >>> a.__bool__()
         False
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__bool__", (self,))
+
         return not gequal0(self.g)
 
+    @_owner_method
     def gequal(a, b):
         r"""
         Check whether `a` and `b` are equal using PARI's ``gequal``.
@@ -2089,6 +2243,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return ret != 0
 
+    @_owner_method
     def gequal0(a):
         r"""
         Check whether `a` is equal to zero.
@@ -2114,6 +2269,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return ret != 0
 
+    @_owner_method
     def gequal_long(a, long b):
         r"""
         Check whether `a` is equal to the ``long int`` `b` using PARI's ``gequalsg``.
@@ -2144,6 +2300,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return ret != 0
 
+    @_owner_method
     def isprime(self, long flag=0):
         """
         Return True if x is a PROVEN prime number, and False otherwise.
@@ -2184,6 +2341,7 @@ cdef class Gen(Gen_base):
         clear_stack()
         return ret
 
+    @_owner_method
     def ispseudoprime(self, long flag=0):
         """
         Returns ``True`` if ``x`` is a strong pseudo prime number, and 
@@ -2228,6 +2386,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return t != 0
 
+    @_owner_method
     def ispower(self, k=None):
         r"""
         Determine whether or not self is a perfect k-th power. If k is not
@@ -2284,6 +2443,7 @@ cdef class Gen(Gen_base):
             else:
                 return k, new_gen(x)
 
+    @_owner_method
     def isprimepower(self):
         r"""
         Check whether ``self`` is a prime power (with an exponent >= 1).
@@ -2330,6 +2490,7 @@ cdef class Gen(Gen_base):
         else:
             return n, new_gen(x)
 
+    @_owner_method
     def ispseudoprimepower(self):
         r"""
         Check whether ``self`` is the power (with an exponent >= 1) of
@@ -2370,6 +2531,7 @@ cdef class Gen(Gen_base):
         else:
             return n, new_gen(x)
 
+    @_owner_method
     def vecmax(x):
         """
         Return the maximum of the elements of the vector/matrix `x`.
@@ -2385,6 +2547,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(vecmax(x.g))
 
+    @_owner_method
     def vecmin(x):
         """
         Return the minimum of the elements of the vector/matrix `x`.
@@ -2400,6 +2563,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(vecmin(x.g))
 
+    @_owner_method
     def Ser(f, v=None, long precision=-1):
         """
         Return a power series or Laurent series in the variable `v`
@@ -2474,6 +2638,7 @@ cdef class Gen(Gen_base):
         else:
             return new_gen(gtoser(f.g, vn, precision))
 
+    @_owner_method
     def Str(self):
         """
         Str(self): Return the print representation of self as a PARI
@@ -2520,6 +2685,7 @@ cdef class Gen(Gen_base):
         pari_free(c)
         return v
 
+    @_owner_method
     def Strexpand(x):
         """
         Concatenate the entries of the vector `x` into a single string,
@@ -2556,6 +2722,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(Strexpand(x.g))
 
+    @_owner_method
     def Strtex(x):
         r"""
         Strtex(x): Translates the vector x of PARI gens to TeX format and
@@ -2590,6 +2757,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(Strtex(x.g))
 
+    @_owner_method
     def bittest(x, long n):
         """
         bittest(x, long n): Returns bit number n (coefficient of
@@ -2636,6 +2804,7 @@ cdef class Gen(Gen_base):
 
     lift_centered = Gen_base.centerlift
 
+    @_owner_method
     def padicprime(self):
         """
         The uniformizer of the p-adic ring this element lies in, as a t_INT.
@@ -2661,6 +2830,7 @@ cdef class Gen(Gen_base):
         """
         return self.new_ref(gel(self.fixGEN(), 2))
 
+    @_owner_method
     def round(x, bint estimate=False):
         """
         round(x,estimate=False): If x is a real number, returns x rounded
@@ -2719,6 +2889,7 @@ cdef class Gen(Gen_base):
         y = new_gen(grndtoi(x.g, &e))
         return y, e
 
+    @_owner_method
     def sizeword(x):
         """
         Return the total number of machine words occupied by the
@@ -2757,6 +2928,7 @@ cdef class Gen(Gen_base):
         """
         return gsizeword(x.g)
 
+    @_owner_method
     def sizebyte(x):
         """
         Return the total number of bytes occupied by the complete tree
@@ -2781,6 +2953,7 @@ cdef class Gen(Gen_base):
         """
         return gsizebyte(x.g)
 
+    @_owner_method
     def truncate(x, bint estimate=False):
         """
         truncate(x,estimate=False): Return the truncation of x. If estimate
@@ -2847,6 +3020,7 @@ cdef class Gen(Gen_base):
         y = new_gen(gcvtoi(x.g, &e))
         return y, e
 
+    @_owner_method
     def _valp(x):
         """
         Return the valuation of x where x is a p-adic number (t_PADIC)
@@ -2870,6 +3044,7 @@ cdef class Gen(Gen_base):
         # This is a simple macro, so we don't need sig_on()
         return valp(x.g)
 
+    @_owner_method
     def bernfrac(self):
         r"""
         The Bernoulli number `B_x`, where `B_0 = 1`,
@@ -2890,6 +3065,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(bernfrac(self))
 
+    @_owner_method
     def bernreal(self, unsigned long precision=DEFAULT_BITPREC):
         r"""
         The Bernoulli number `B_x`, as for the function bernfrac,
@@ -2907,6 +3083,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(bernreal(self, nbits2prec(precision)))
 
+    @_owner_method
     def besselk(nu, x, unsigned long precision=DEFAULT_BITPREC):
         """
         nu.besselk(x): K-Bessel function (modified Bessel function
@@ -2944,6 +3121,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(kbessel(nu.g, t0.g, nbits2prec(precision)))
 
+    @_owner_method
     def eint1(x, long n=0, unsigned long precision=DEFAULT_BITPREC):
         r"""
         x.eint1(n): exponential integral E1(x):
@@ -2976,6 +3154,7 @@ cdef class Gen(Gen_base):
 
     log_gamma = Gen_base.lngamma
 
+    @_owner_method
     def polylog(x, long m, long flag=0,
                 unsigned long precision=DEFAULT_BITPREC):
         """
@@ -3008,6 +3187,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(polylog0(m, x.g, flag, nbits2prec(precision)))
 
+    @_owner_method
     def sqrtn(x, n, unsigned long precision=DEFAULT_BITPREC):
         r"""
         x.sqrtn(n): return the principal branch of the n-th root of x,
@@ -3073,6 +3253,7 @@ cdef class Gen(Gen_base):
         ans = gsqrtn(x.g, t0.g, &zetan, nbits2prec(precision))
         return new_gens2(ans, zetan)
 
+    @_owner_method
     def ffprimroot(self):
         r"""
         Return a primitive root of the multiplicative group of the
@@ -3099,6 +3280,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(ffprimroot(self.g, NULL))
 
+    @_owner_method
     def fibonacci(self):
         r"""
         Return the Fibonacci number of index x.
@@ -3116,6 +3298,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(fibo(self))
 
+    @_owner_method
     def issquare(x, find_root=False):
         """
         issquare(x,n): ``True`` if x is a square, ``False`` if not. If
@@ -3136,6 +3319,7 @@ cdef class Gen(Gen_base):
             clear_stack()
             return t != 0
 
+    @_owner_method
     def issquarefree(self):
         """
         Examples:
@@ -3153,6 +3337,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return t != 0
 
+    @_owner_method
     def sumdiv(n):
         """
         Return the sum of the divisors of `n`.
@@ -3168,6 +3353,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(sumdiv(n.g))
 
+    @_owner_method
     def sumdivk(n, long k):
         """
         Return the sum of the k-th powers of the divisors of n.
@@ -3183,6 +3369,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(sumdivk(n.g, k))
 
+    @_owner_method
     def Zn_issquare(self, n):
         """
         Return ``True`` if ``self`` is a square modulo `n`, ``False``
@@ -3211,6 +3398,7 @@ cdef class Gen(Gen_base):
         clear_stack()
         return t != 0
 
+    @_owner_method
     def Zn_sqrt(self, n):
         """
         Return a square root of ``self`` modulo `n`, if such a square
@@ -3244,6 +3432,7 @@ cdef class Gen(Gen_base):
             raise ValueError("%s is not a square modulo %s" % (self, n))
         return new_gen(s)
 
+    @_owner_method
     def ellan(self, long n, python_ints=False):
         """
         Return the first `n` Fourier coefficients of the modular
@@ -3283,6 +3472,7 @@ cdef class Gen(Gen_base):
             return g
         return [gtolong(gel(g.g, i+1)) for i in range(glength(g.g))]
 
+    @_owner_method
     def ellaplist(self, long n, python_ints=False):
         r"""
         e.ellaplist(n): Returns a PARI list of all the prime-indexed
@@ -3356,6 +3546,7 @@ cdef class Gen(Gen_base):
             set_gel(g, i, ellap(curve, utoi(g[i])))
         return new_gen(g)
 
+    @_owner_method
     def ellisoncurve(self, x):
         """
         e.ellisoncurve(x): return True if the point x is on the elliptic
@@ -3387,6 +3578,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return t != 0
 
+    @_owner_method
     def ellminimalmodel(self):
         """
         ellminimalmodel(e): return the standard minimal integral model of
@@ -3424,6 +3616,7 @@ cdef class Gen(Gen_base):
         x = ellminimalmodel(self.g, &y)
         return new_gens2(x, y)
 
+    @_owner_method
     def elltors(self):
         r"""
         Return information about the torsion subgroup of the given
@@ -3459,6 +3652,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(elltors(self.g))
 
+    @_owner_method
     def omega(self):
         """
         Return the basis for the period lattice of this elliptic curve.
@@ -3487,6 +3681,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(member_omega(self.g))
 
+    @_owner_method
     def disc(self):
         """
         Return the discriminant of this object.
@@ -3505,6 +3700,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_disc(self.g))
 
+    @_owner_method
     def j(self):
         """
         Return the j-invariant of this object.
@@ -3523,6 +3719,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(member_j(self.g))
 
+    @_owner_method
     def _eltabstorel(self, x):
         """
         Return the relative number field element corresponding to `x`.
@@ -3554,6 +3751,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(eltabstorel(self.g, t0.g))
 
+    @_owner_method
     def _eltabstorel_lift(self, x):
         """
         Return the relative number field element corresponding to `x`.
@@ -3581,6 +3779,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(eltabstorel_lift(self.g, t0.g))
 
+    @_owner_method
     def _eltreltoabs(self, x):
         """
         Return the absolute number field element corresponding to `x`.
@@ -3610,6 +3809,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(eltreltoabs(self.g, t0.g))
 
+    @_owner_method
     def galoissubfields(self, long flag=0, v=None):
         """
         List all subfields of the Galois group ``self``.
@@ -3650,6 +3850,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(galoissubfields(self.g, flag, get_var(v)))
 
+    @_owner_method
     def nfeltval(self, x, p):
         """
         Return the valuation of the number field element `x` at the prime `p`.
@@ -3671,6 +3872,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return v
 
+    @_owner_method
     def nfbasis(self, long flag=0, fa=None):
         r"""
         Integral basis of the field `\QQ[a]`, where ``a`` is a root of
@@ -3743,6 +3945,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(old_nfbasis(self.g, NULL, g0))
 
+    @_owner_method
     def nfbasis_d(self, long flag=0, fa=None):
         """
         Like :meth:`nfbasis`, but return a tuple ``(B, D)`` where `B`
@@ -3778,6 +3981,7 @@ cdef class Gen(Gen_base):
         ans = old_nfbasis(self.g, &disc, g0)
         return new_gens2(ans, disc)
 
+    @_owner_method
     def nfbasistoalg_lift(nf, x):
         r"""
         Transforms the column vector ``x`` on the integral basis into a
@@ -3812,11 +4016,13 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(gel(basistoalg(nf.g, t0.g), 2))
 
+    @_owner_method
     def nfgenerator(self):
         f = self[0]
         x = f.variable()
         return x.Mod(f)
 
+    @_owner_method
     def _nf_rnfeq(self, relpol):
         """
         Return data for converting number field elements between
@@ -3841,6 +4047,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(nf_rnfeq(self.g, t0.g))
 
+    @_owner_method
     def _nf_nfzk(self, rnfeq):
         """
         Return data for constructing relative number field elements
@@ -3860,6 +4067,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(new_nf_nfzk(self.g, t0.g))
 
+    @_owner_method
     def _nfeltup(self, x, nfzk):
         """
         Construct a relative number field element from an element of
@@ -3894,6 +4102,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return clone_gen(new_nfeltup(self.g, t0.g, t1.g))
 
+    @_owner_method
     def eval(self, *args, **kwds):
         """
         Evaluate ``self`` with the given arguments.
@@ -4071,6 +4280,9 @@ cdef class Gen(Gen_base):
         """
         Evaluate ``self`` with the given arguments. See ``eval``.
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__call__", (self,) + args, kwds)
+
         cdef long t = typ(self.g)
         cdef Gen t0
         cdef GEN result
@@ -4123,6 +4335,7 @@ cdef class Gen(Gen_base):
             set_gel(v, i+1, pol_x(fetch_user_var(varname)))
         return new_gen(gsubstvec(self.g, v, t0.g))
 
+    @_owner_method
     def arity(self):
         """
         Return the number of arguments of this ``t_CLOSURE``.
@@ -4140,6 +4353,7 @@ cdef class Gen(Gen_base):
             raise TypeError("arity() requires a t_CLOSURE")
         return closure_arity(self.g)
 
+    @_owner_method
     def factorpadic(self, p, long r=20):
         """
         p-adic factorization of the polynomial ``pol`` to precision ``r``.
@@ -4159,6 +4373,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(factorpadic(self.g, t0.g, r))
 
+    @_owner_method
     def ncols(self):
         """
         Return the number of columns of self.
@@ -4177,6 +4392,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return n
 
+    @_owner_method
     def nrows(self):
         """
         Return the number of rows of self.
@@ -4200,6 +4416,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return n
 
+    @_owner_method
     def mattranspose(self):
         """
         Transpose of the matrix self.
@@ -4222,12 +4439,15 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(gtrans(self.g)).Mat()
 
+    @_owner_method
     def lllgram(self):
         return self.qflllgram(0)
 
+    @_owner_method
     def lllgramint(self):
         return self.qflllgram(1)
 
+    @_owner_method
     def qfrep(self, B, long flag=0):
         """
         Vector of (half) the number of vectors of norms from 1 to `B`
@@ -4259,6 +4479,7 @@ cdef class Gen(Gen_base):
             r = vecsmall_to_vec(r)
         return new_gen(r)
 
+    @_owner_method
     def matkerint(self, long flag=0):
         """
         Return the integer kernel of a matrix.
@@ -4289,6 +4510,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(matkerint0(self.g, flag))
 
+    @_owner_method
     def factor(self, long limit=-1, proof=None):
         """
         Return the factorization of x.
@@ -4351,8 +4573,12 @@ cdef class Gen(Gen_base):
     multiplicative_order = Gen_base.znorder
 
     def __abs__(self):
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(Gen, "__abs__", (self,))
+
         return self.abs()
 
+    @_owner_method
     def nextprime(self, bint add_one=False):
         """
         nextprime(x): smallest pseudoprime greater than or equal to `x`.
@@ -4378,6 +4604,7 @@ cdef class Gen(Gen_base):
             return new_gen(nextprime(gaddsg(1, self.g)))
         return new_gen(nextprime(self.g))
 
+    @_owner_method
     def change_variable_name(self, var):
         """
         In ``self``, which must be a ``t_POL`` or ``t_SER``, set the
@@ -4428,6 +4655,7 @@ cdef class Gen(Gen_base):
         setvarn(newg.g, n)
         return newg
 
+    @_owner_method
     def nf_subst(self, z):
         """
         Given a PARI number field ``self``, return the same PARI
@@ -4470,6 +4698,7 @@ cdef class Gen(Gen_base):
         sig_on()
         return new_gen(gsubst(self.g, gvar(self.g), t0.g))
 
+    @_owner_method
     def type(self):
         """
         Return the PARI type of self as a string.
@@ -4496,6 +4725,7 @@ cdef class Gen(Gen_base):
         sig_off()
         return to_string(s)
 
+    @_owner_method
     def polinterpolate(self, ya, x):
         """
         self.polinterpolate(ya,x,e): polynomial interpolation at x
@@ -4510,6 +4740,7 @@ cdef class Gen(Gen_base):
         g = polint(self.g, t0.g, t1.g, &dy)
         return new_gens2(g, dy)
 
+    @_owner_method
     def ellwp(self, z='z', long n=20, long flag=0,
               unsigned long precision=DEFAULT_BITPREC):
         """
@@ -4595,6 +4826,7 @@ cdef class Gen(Gen_base):
             set_gel(r, 2, gmulgs(gel(r, 2), 2))
         return new_gen(r)
 
+    @_owner_method
     def debug(self, long depth=-1):
         r"""
         Show the internal structure of self (like the ``\x`` command in gp).
@@ -4614,10 +4846,14 @@ cdef class Gen(Gen_base):
             imag = [&=...] REAL(lg=...):... (+,expo=0):...
         """
         sig_on()
-        dbgGEN(self.g, depth)
+        # Values crossing the owner boundary are heap clones.  Debug a stack
+        # copy so this diagnostic keeps the same observable format as before
+        # (in particular, it must not grow a ``CLONE`` marker).
+        dbgGEN(gcopy(self.g), depth)
         clear_stack()
         return
 
+    @_owner_method
     def allocatemem(self, *args):
         """
         Do not use this. Use ``pari.allocatemem()`` instead.
@@ -4780,6 +5016,9 @@ cpdef Gen objtogen(s):
     ValueError: Cannot convert None to pari
 
     """
+    if not _pari_thread_runtime.is_owner():
+        return _pari_thread_runtime.call(objtogen, s)
+
     if isinstance(s, Gen):
         return s
 
@@ -4821,3 +5060,24 @@ cpdef Gen objtogen(s):
 
     # Simply use the string representation
     return objtogen(str(s))
+
+
+def _free_owner_clone(size_t address):
+    """Free a clone on the only thread allowed to mutate its registry."""
+    if address:
+        gunclone_deep(<GEN>address)
+
+
+def _stabilize_thread_result(value):
+    """Move every live stack ``Gen`` to the heap before a request ends.
+
+    Moving the full tracked stack also covers a Gen retained through a side
+    effect of arbitrary Python conversion code, where it is not reachable
+    from the request's return value.
+    """
+    move_gens_to_heap(-1)
+    # A stack Gen may have lost its final reference on a foreign Python
+    # thread during a callback.  That thread unlinks the wrapper but cannot
+    # touch PARI's thread-local ``avma``; reclaim any such gap here.
+    reset_avma()
+    return value

--- a/cypari2/handle_error.pyx
+++ b/cypari2/handle_error.pyx
@@ -23,11 +23,13 @@ AUTHORS:
 
 from cpython cimport PyErr_Occurred
 
-from cysignals.signals cimport sig_block, sig_unblock, sig_error
+from cysignals.signals cimport sig_block, sig_unblock
 
 from .paridecl cimport *
 from .paripriv cimport *
 from .stack cimport clone_gen_noclear, reset_avma, after_resize
+from .thread_support cimport sig_error_local
+from ._thread_runtime import runtime as _pari_thread_runtime
 
 
 # We derive PariError from RuntimeError, for backward compatibility with
@@ -208,6 +210,7 @@ cdef int _pari_err_handle(GEN E) except 0:
     if s is not NULL:
         pari_error_string = s.decode('ascii') + ": " + pari_error_string
 
+    _pari_thread_runtime.note_callback_pari_error()
     raise PariError(errnum, pari_error_string, clone_gen_noclear(E))
 
 
@@ -228,4 +231,4 @@ cdef void _pari_err_recover(long errnum) noexcept:
 
     # An exception was raised.  Jump to the signal-handling code
     # which will cause sig_on() to see the exception.
-    sig_error()
+    sig_error_local()

--- a/cypari2/meson.build
+++ b/cypari2/meson.build
@@ -1,5 +1,6 @@
 py.install_sources(
   '__init__.py',
+  '_thread_runtime.py',
   'closure.pxd',
   'convert.pxd',
   'gen.pxd',
@@ -10,6 +11,7 @@ py.install_sources(
   'pycore_long.pxd',
   'stack.pxd',
   'string_utils.pxd',
+  'thread_support.pxd',
   'types.pxd',
   'cypari.h',
   'pycore_long.h',
@@ -41,7 +43,7 @@ foreach name, pyx : extension_data
     sources: pyx,
     subdir: 'cypari2',
     install: true,
-    dependencies: [cysignals, pari],
+    dependencies: [cysignals, pari, threads],
     include_directories: [inc_root, inc_src],
   )
 endforeach
@@ -58,5 +60,10 @@ configure_file(
 configure_file(
   input: '__init__.py',
   output: '__init__.py',
+  copy: true,
+)
+configure_file(
+  input: '_thread_runtime.py',
+  output: '_thread_runtime.py',
   copy: true,
 )

--- a/cypari2/pari_instance.pyx
+++ b/cypari2/pari_instance.pyx
@@ -288,7 +288,7 @@ import sys
 from libc.stdio cimport *
 cimport cython
 
-from cysignals.signals cimport sig_check, sig_on, sig_off, sig_error
+from cysignals.signals cimport sig_check, sig_on, sig_off
 
 from .string_utils cimport to_string, to_bytes
 from .paridecl cimport *
@@ -298,6 +298,11 @@ from .stack cimport (new_gen, new_gen_noclear, clear_stack,
                      set_pari_stack_size, before_resize, after_resize)
 from .handle_error cimport _pari_init_error_handling
 from .closure cimport _pari_init_closure
+from .thread_support cimport (install_signal_router, set_signal_owner_active,
+                              is_signal_owner)
+from ._thread_runtime import (owner_method as _owner_method,
+                              runtime as _pari_thread_runtime)
+from .thread_support cimport sig_error_local
 
 
 #################################################################
@@ -412,8 +417,11 @@ def prec_words_to_dec(long prec_in_words):
 # Callbacks from PARI to print stuff using sys.stdout.write() instead
 # of C library functions like puts().
 cdef PariOUT python_pariOut
+cdef extern from "pari/pari.h":
+    void pari_err_nogil "pari_err"(int, ...) noexcept nogil
+    void pari_set_last_newline_nogil "pari_set_last_newline"(int) noexcept nogil
 
-cdef void python_putchar(char c) noexcept:
+cdef void python_putchar_owner(char c) noexcept:
     cdef char s[2]
     s[0] = c
     s[1] = 0
@@ -424,18 +432,41 @@ cdef void python_putchar(char c) noexcept:
         sys.stdout.write(to_string(s))
     # Let PARI think the last character was a newline,
     # so it doesn't print one when an error occurs.
-    pari_set_last_newline(1)
+    pari_set_last_newline_nogil(1)
 
-cdef void python_puts(const char* s) noexcept:
+cdef void python_puts_owner(const char* s) noexcept:
     try:
         # avoid string conversion if possible
         sys.stdout.buffer.write(s)
     except AttributeError:
         sys.stdout.write(to_string(s))
-    pari_set_last_newline(1)
+    pari_set_last_newline_nogil(1)
 
-cdef void python_flush() noexcept:
+cdef void python_flush_owner() noexcept:
     sys.stdout.flush()
+
+cdef void python_putchar(char c) noexcept nogil:
+    if not is_signal_owner():
+        fputc(c, stdout)
+        pari_set_last_newline_nogil(1)
+        return
+    with gil:
+        python_putchar_owner(c)
+
+cdef void python_puts(const char* s) noexcept nogil:
+    if not is_signal_owner():
+        fputs(s, stdout)
+        pari_set_last_newline_nogil(1)
+        return
+    with gil:
+        python_puts_owner(s)
+
+cdef void python_flush() noexcept nogil:
+    if not is_signal_owner():
+        fflush(stdout)
+        return
+    with gil:
+        python_flush_owner()
 
 include 'auto_instance.pxi'
 
@@ -453,6 +484,10 @@ cdef class Pari(Pari_auto):
         >>> pari = Pari()
         >>> pari("print('hello')")
         """
+        if not _pari_thread_runtime.is_owner():
+            _pari_thread_runtime.ensure_initialized()
+            return
+
         # PARI is already initialized, nothing to do...
         if avma:
             return
@@ -469,6 +504,7 @@ cdef class Pari(Pari_auto):
 
         _pari_init_error_handling()
         _pari_init_closure()
+        install_signal_router()
 
         # Set printing functions
         global pariOut, pariErr
@@ -564,12 +600,16 @@ cdef class Pari(Pari_auto):
 
         .. NOTE::
 
-           Normally, all results from PARI computations end up on the
-           PARI stack. CyPari2 tries to keep everything on the PARI
-           stack. However, if over half of the PARI stack space is used,
-           all live objects on the PARI stack are copied to the PARI
-           heap (they become so-called clones).
+           Results may live on the PARI stack while an owner-thread request
+           is running. Before that request returns to another Python thread,
+           all live stack objects are copied to the PARI heap (they become
+           so-called clones).
         """
+        if not _pari_thread_runtime.is_owner():
+            _pari_thread_runtime.call_type_method(
+                Pari, "__init__", (self, size, sizemax, maxprime))
+            return
+
         # Increase (but don't decrease) size and sizemax to the
         # requested value
         size = max(size, pari_mainstack.rsize)
@@ -590,6 +630,7 @@ cdef class Pari(Pari_auto):
             if "IPython" in sys.modules:
                 pari_set_plot_engine(get_plot_ipython)
 
+    @_owner_method
     def debugstack(self):
         r"""
         Print the internal PARI variables ``top`` (top of stack), ``avma``
@@ -612,18 +653,21 @@ cdef class Pari(Pari_auto):
     def __hash__(self):
         return 907629390
 
+    @_owner_method
     def set_debug_level(self, level):
         """
         Set the debug PARI C library variable.
         """
         self.default('debug', int(level))
 
+    @_owner_method
     def get_debug_level(self):
         """
         Set the debug PARI C library variable.
         """
         return int(self.default('debug'))
 
+    @_owner_method
     def set_real_precision_bits(self, n):
         """
         Sets the PARI default real precision in bits.
@@ -653,6 +697,7 @@ cdef class Pari(Pari_auto):
         sd_realbitprecision(strn, d_SILENT)
         clear_stack()
 
+    @_owner_method
     def get_real_precision_bits(self):
         """
         Return the current PARI default real precision in bits.
@@ -680,6 +725,7 @@ cdef class Pari(Pari_auto):
         clear_stack()
         return r
 
+    @_owner_method
     def set_real_precision(self, long n):
         """
         Sets the PARI default real precision in decimal digits.
@@ -711,6 +757,7 @@ cdef class Pari(Pari_auto):
         self.set_real_precision_bits(prec_dec_to_bits(n))
         return old
 
+    @_owner_method
     def get_real_precision(self):
         """
         Returns the current PARI default real precision.
@@ -738,13 +785,16 @@ cdef class Pari(Pari_auto):
         sig_off()
         return r
 
+    @_owner_method
     def set_series_precision(self, long n):
         global precdl
         precdl = n
 
+    @_owner_method
     def get_series_precision(self):
         return precdl
 
+    @_owner_method
     def version(self):
         """
         Return the PARI version as tuple with 3 or 4 components:
@@ -758,6 +808,7 @@ cdef class Pari(Pari_auto):
         """
         return tuple(Pari_auto.version(self))
 
+    @_owner_method
     def complex(self, re, im):
         """
         Create a new complex number, initialized from re and im.
@@ -797,6 +848,10 @@ cdef class Pari(Pari_auto):
 
         See :func:`objtogen` for more examples.
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(
+                Pari, "__call__", (self, s))
+
         cdef Gen g = objtogen(s)
         if g.g is gnil:
             return None
@@ -811,6 +866,9 @@ cdef class Pari(Pari_auto):
         >>> pari.zero()
         0
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(
+                Pari, "zero", (self,))
         return self.PARI_ZERO
 
     cpdef Gen one(self):
@@ -822,8 +880,12 @@ cdef class Pari(Pari_auto):
         >>> pari.one()
         1
         """
+        if not _pari_thread_runtime.is_owner():
+            return _pari_thread_runtime.call_type_method(
+                Pari, "one", (self,))
         return self.PARI_ONE
 
+    @_owner_method
     def new_with_bits_prec(self, s, long precision):
         r"""
         pari.new_with_bits_prec(self, s, precision) creates s as a PARI
@@ -844,6 +906,7 @@ cdef class Pari(Pari_auto):
     # Initialization
     ############################################################
 
+    @_owner_method
     def stacksize(self):
         r"""
         Return the current size of the PARI stack, which is `10^6`
@@ -868,6 +931,7 @@ cdef class Pari(Pari_auto):
         """
         return pari_mainstack.size
 
+    @_owner_method
     def stacksizemax(self):
         r"""
         Return the maximum size of the PARI stack, which is determined
@@ -891,6 +955,7 @@ cdef class Pari(Pari_auto):
         """
         return pari_mainstack.vsize
 
+    @_owner_method
     def allocatemem(self, size_t s=0, size_t sizemax=0, *, silent=False):
         r"""
         Change the PARI stack space to the given size ``s`` (or double
@@ -1006,6 +1071,7 @@ cdef class Pari(Pari_auto):
         """
         return to_string(PARIVERSION)
 
+    @_owner_method
     def init_primes(self, unsigned long M):
         """
         Recompute the primes table including at least all primes up to M
@@ -1034,6 +1100,7 @@ cdef class Pari(Pari_auto):
         initprimetable(M)
         sig_off()
 
+    @_owner_method
     def primes(self, n=None, end=None):
         """
         Return a pari vector containing the first `n` primes, the primes
@@ -1109,6 +1176,7 @@ cdef class Pari(Pari_auto):
     euler = Pari_auto.Euler
     pi = Pari_auto.Pi
 
+    @_owner_method
     def polchebyshev(self, long n, v=None):
         """
         Chebyshev polynomial of the first kind of degree `n`,
@@ -1128,6 +1196,7 @@ cdef class Pari(Pari_auto):
         sig_on()
         return new_gen(polchebyshev1(n, get_var(v)))
 
+    @_owner_method
     def factorial_int(self, long n):
         """
         Return the factorial of the integer n as a PARI gen.
@@ -1149,6 +1218,7 @@ cdef class Pari(Pari_auto):
         sig_on()
         return new_gen(mpfact(n))
 
+    @_owner_method
     def polsubcyclo(self, long n, long d, v=None):
         r"""
         polsubcyclo(n, d, v=x): return the pari list of polynomial(s)
@@ -1178,6 +1248,7 @@ cdef class Pari(Pari_auto):
         else:
             return plist
 
+    @_owner_method
     def setrand(self, seed):
         """
         Sets PARI's current random number seed.
@@ -1211,6 +1282,7 @@ cdef class Pari(Pari_auto):
         setrand(t0.g)
         sig_off()
 
+    @_owner_method
     def vector(self, long n, entries=None):
         """
         vector(long n, entries=None): Create and return the length n PARI
@@ -1244,6 +1316,7 @@ cdef class Pari(Pari_auto):
         v = new_gen(zerovec(n))
         return v
 
+    @_owner_method
     def matrix(self, long m, long n, entries=None):
         """
         matrix(long m, long n, entries=None): Create and return the m x n
@@ -1276,6 +1349,7 @@ cdef class Pari(Pari_auto):
                     k += 1
         return A
 
+    @_owner_method
     def genus2red(self, P, p=None):
         r"""
         Let `P` be a polynomial with integer coefficients.
@@ -1306,6 +1380,7 @@ cdef class Pari(Pari_auto):
         sig_on()
         return new_gen(genus2red(t0.g, t1.g))
 
+    @_owner_method
     def List(self, x=None):
         """
         Create an empty list or convert `x` to a list.
@@ -1334,6 +1409,16 @@ cdef class Pari(Pari_auto):
         cdef Gen t0 = objtogen(x)
         sig_on()
         return new_gen(gtolist(t0.g))
+
+
+def _initialize_pari_owner():
+    """Initialize libpari from its permanent owner thread."""
+    Pari()
+
+
+def _set_owner_request_active(active):
+    """Tell the signal router whether the owner is servicing a request."""
+    set_signal_owner_active(bool(active))
 
 
 cdef long get_var(v) except -2:
@@ -1406,16 +1491,22 @@ cdef long get_var(v) except -2:
 # which call before_resize() and after_resize().
 # The monkey-patching is set up in PariInstance.__cinit__
 cdef GEN patched_parisize(const char* v, long flag) noexcept:
+    if not is_signal_owner():
+        pari_err(e_MISC, "PARI stack resizing cannot run in a PARI worker thread")
+        return NULL
     # Cast to `int(*)() noexcept` to avoid exception handling
     if (<int(*)() noexcept>before_resize)():
-        sig_error()
+        sig_error_local()
     return sd_parisize(v, flag)
 
 
 cdef GEN patched_parisizemax(const char* v, long flag) noexcept:
+    if not is_signal_owner():
+        pari_err(e_MISC, "PARI stack resizing cannot run in a PARI worker thread")
+        return NULL
     # Cast to `int(*)() noexcept` to avoid exception handling
     if (<int(*)() noexcept>before_resize)():
-        sig_error()
+        sig_error_local()
     return sd_parisizemax(v, flag)
 
 
@@ -1431,10 +1522,22 @@ IF HAVE_PLOT_SVG:
 
         T.draw = draw_ipython
 
-    cdef void draw_ipython(PARI_plot *T, GEN w, GEN x, GEN y) noexcept:
+    cdef void draw_ipython_owner(PARI_plot *T, GEN w, GEN x, GEN y) noexcept:
         global avma
         cdef pari_sp av = avma
         cdef char* svg = rect2svg(w, x, y, T)
-        from IPython.core.display import SVG, display
-        display(SVG(svg))
-        avma = av
+        try:
+            from IPython.core.display import SVG, display
+            display(SVG(svg))
+        finally:
+            avma = av
+
+    cdef void draw_ipython(PARI_plot *T, GEN w, GEN x, GEN y) noexcept nogil:
+        if not is_signal_owner():
+            pari_err_nogil(
+                e_MISC,
+                "IPython plotting cannot run in a PARI worker thread",
+            )
+            return
+        with gil:
+            draw_ipython_owner(T, w, x, y)

--- a/cypari2/stack.pxd
+++ b/cypari2/stack.pxd
@@ -13,6 +13,7 @@ cdef void reset_avma() noexcept
 
 cdef void remove_from_pari_stack(Gen self) noexcept
 cdef int move_gens_to_heap(pari_sp lim) except -1
+cdef int move_gens_above_to_heap(Gen boundary) except -1
 
 cdef int before_resize() except -1
 cdef int set_pari_stack_size(size_t size, size_t sizemax) except -1

--- a/cypari2/stack.pyx
+++ b/cypari2/stack.pyx
@@ -19,14 +19,15 @@ cimport cython
 from cpython.ref cimport PyObject, _Py_REFCNT
 from cpython.exc cimport PyErr_SetString
 
-from cysignals.signals cimport (sig_on, sig_off, sig_block, sig_unblock,
-                                sig_error)
+from cysignals.signals cimport sig_on, sig_off, sig_block, sig_unblock
 
 from .gen cimport Gen, Gen_new
 from .paridecl cimport (avma, pari_mainstack, gnil, gcopy,
                         is_universal_constant, is_on_stack,
                         isclone, gclone, gclone_refc,
                         paristack_setsize)
+from ._thread_runtime import runtime as _pari_thread_runtime
+from .thread_support cimport sig_error_local
 
 from warnings import warn
 
@@ -49,13 +50,29 @@ cdef PyObject* stackbottom = <PyObject*>top_of_stack
 
 cdef void remove_from_pari_stack(Gen self) noexcept:
     global avma, stackbottom
+    if not _pari_thread_runtime.is_owner():
+        # A Python callback can hand a newly-created stack Gen to another
+        # Python thread before the enclosing owner request has returned.  If
+        # that thread drops the last reference, only unlink the Python object
+        # here: ``avma`` is PARI TLS and must be restored by the owner.  The
+        # linked-list invariant means that an object whose reference count
+        # reached zero is necessarily the current stack bottom.  Holding ``n``
+        # across clearing ``self.next`` also makes recursive deallocation of
+        # now-unreferenced predecessors follow the same safe path.
+        if <PyObject*>self is not stackbottom:
+            print("ERROR: removing non-current PARI stack Gen on a foreign thread")
+            return
+        n = self.next
+        stackbottom = <PyObject*>n
+        self.next = None
+        return
     if <PyObject*>self is not stackbottom:
         print("ERROR: removing wrong instance of Gen")
         print(f"Expected: {<object>stackbottom}")
         print(f"Actual:   {self}")
     if sig_on_count and not block_sigint:
         PyErr_SetString(SystemError, "calling remove_from_pari_stack() inside sig_on()")
-        sig_error()
+        sig_error_local()
     if self.sp() != avma:
         if avma > self.sp():
             print("ERROR: inconsistent avma when removing Gen from PARI stack")
@@ -134,6 +151,21 @@ cdef int move_gens_to_heap(pari_sp lim) except -1:
         # The more important .g attribute is updated correctly before
         # remove_from_pari_stack(). Therefore, the object can be used
         # normally regardless of what happens to the PARI stack.
+        current.address = current.g
+
+
+cdef int move_gens_above_to_heap(Gen boundary) except -1:
+    """Move stack Gens created after ``boundary`` to the clone heap."""
+    while stackbottom is not <PyObject*>boundary:
+        if stackbottom is <PyObject*>top_of_stack:
+            raise SystemError("PARI stack boundary is no longer linked")
+        current = <Gen>stackbottom
+        sig_on()
+        current.g = gclone(current.g)
+        sig_block()
+        remove_from_pari_stack(current)
+        sig_unblock()
+        sig_off()
         current.address = current.g
 
 

--- a/cypari2/thread_support.pxd
+++ b/cypari2/thread_support.pxd
@@ -1,0 +1,229 @@
+"""Low-level helpers for the single PARI owner thread."""
+
+from cysignals.signals cimport cysigs
+
+
+cdef extern from *:
+    """
+    #include <signal.h>
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #include "struct_signals.h"
+
+    #ifndef _WIN32
+    #include <pthread.h>
+
+    static pthread_t cypari2_signal_owner;
+    static cysigs_t *cypari2_signal_state;
+    static volatile sig_atomic_t cypari2_signal_owner_ready;
+    static volatile sig_atomic_t cypari2_signal_owner_active;
+    static volatile sig_atomic_t cypari2_signal_router_ready;
+    static const int cypari2_routed_signals[] = { SIGINT, SIGALRM, SIGHUP };
+    static struct sigaction cypari2_original_actions[3];
+
+    static void
+    cypari2_call_original_signal_handler(int index, int sig,
+                                         siginfo_t *info, void *context)
+    {
+        struct sigaction *action = &cypari2_original_actions[index];
+        if (action->sa_handler == SIG_IGN)
+            return;
+        if (action->sa_handler == SIG_DFL)
+        {
+            signal(sig, SIG_DFL);
+            raise(sig);
+            return;
+        }
+        if (action->sa_flags & SA_SIGINFO)
+            action->sa_sigaction(sig, info, context);
+        else
+            action->sa_handler(sig);
+    }
+
+    static void
+    cypari2_signal_router(int sig, siginfo_t *info, void *context)
+    {
+        int index;
+        for (index = 0; index < 3; index++)
+            if (cypari2_routed_signals[index] == sig)
+                break;
+        if (index == 3)
+            return;
+
+        if (cypari2_signal_owner_ready && cypari2_signal_owner_active &&
+            cypari2_signal_state != NULL &&
+            cypari2_signal_state->sig_on_count > 0 &&
+            !pthread_equal(pthread_self(), cypari2_signal_owner))
+        {
+            pthread_kill(cypari2_signal_owner, sig);
+            return;
+        }
+        cypari2_call_original_signal_handler(index, sig, info, context);
+    }
+
+    static int
+    cypari2_install_signal_router(void *opaque)
+    {
+        struct sigaction action;
+        int i;
+        cypari2_signal_owner = pthread_self();
+        cypari2_signal_state = (cysigs_t *)opaque;
+        cypari2_signal_owner_ready = 1;
+        if (cypari2_signal_router_ready)
+            return 0;
+
+        for (i = 0; i < 3; i++)
+            if (sigaction(cypari2_routed_signals[i], NULL,
+                          &cypari2_original_actions[i]) < 0)
+                return -1;
+        for (i = 0; i < 3; i++)
+        {
+            action = cypari2_original_actions[i];
+            action.sa_sigaction = cypari2_signal_router;
+            action.sa_flags |= SA_SIGINFO;
+            if (sigaction(cypari2_routed_signals[i], &action, NULL) < 0)
+            {
+                while (i-- > 0)
+                    sigaction(cypari2_routed_signals[i],
+                              &cypari2_original_actions[i], NULL);
+                return -1;
+            }
+        }
+        cypari2_signal_router_ready = 1;
+        return 0;
+    }
+
+    static void
+    cypari2_set_signal_owner_active(int active)
+    {
+        cypari2_signal_owner_active = !!active;
+    }
+
+    static int
+    cypari2_is_signal_owner(void)
+    {
+        return !cypari2_signal_owner_ready ||
+               pthread_equal(pthread_self(), cypari2_signal_owner);
+    }
+    #else
+    #include <windows.h>
+    static DWORD cypari2_signal_owner;
+    static int cypari2_signal_owner_ready;
+    static int cypari2_install_signal_router(void *opaque)
+    {
+        (void)opaque;
+        cypari2_signal_owner = GetCurrentThreadId();
+        cypari2_signal_owner_ready = 1;
+        return 0;
+    }
+    static void cypari2_set_signal_owner_active(int active)
+    { (void)active; }
+    static int cypari2_is_signal_owner(void)
+    {
+        return !cypari2_signal_owner_ready ||
+               GetCurrentThreadId() == cypari2_signal_owner;
+    }
+    #endif
+
+    typedef struct
+    {
+        cyjmp_buf env;
+        int sig_on_count;
+        int block_sigint;
+        const char *message;
+    } cypari2_callback_signal_frame;
+
+    static void
+    cypari2_sig_error_current_thread(void *opaque)
+    {
+        cysigs_t *state = (cysigs_t *)opaque;
+        if (state->sig_on_count <= 0)
+        {
+            fprintf(stderr, "sig_error_local() without sig_on()\\n");
+            raise(SIGABRT);
+            return;
+        }
+        cylongjmp(state->env, SIGABRT);
+    }
+
+    static void *
+    cypari2_callback_signal_push(void *opaque)
+    {
+        cysigs_t *state = (cysigs_t *)opaque;
+        cypari2_callback_signal_frame *frame =
+            (cypari2_callback_signal_frame *)malloc(sizeof(*frame));
+        if (frame == NULL)
+            return NULL;
+        memcpy(frame->env, state->env, sizeof(frame->env));
+        frame->sig_on_count = state->sig_on_count;
+        frame->block_sigint = state->block_sigint;
+        frame->message = state->s;
+
+        /* A PARI call made by the Python callback must establish its own
+         * jump target.  Otherwise nested sig_on() merely increments the
+         * outer counter and an error jumps across live Python frames. */
+        state->sig_on_count = 0;
+        /* call_python() blocks interrupts around arbitrary Python code.  A
+         * deliberate nested PARI call needs a complete inner signal frame,
+         * though, otherwise SIGINT/SIGALRM remain deferred forever while the
+         * nested computation runs.  With count == 0, signals received by
+         * ordinary Python code are still recorded rather than long-jumping. */
+        state->block_sigint = 0;
+        return frame;
+    }
+
+    static void
+    cypari2_callback_signal_pop(void *opaque, void *saved)
+    {
+        cysigs_t *state = (cysigs_t *)opaque;
+        cypari2_callback_signal_frame *frame =
+            (cypari2_callback_signal_frame *)saved;
+        if (frame == NULL)
+            return;
+        memcpy(state->env, frame->env, sizeof(frame->env));
+        state->sig_on_count = frame->sig_on_count;
+        state->block_sigint = frame->block_sigint;
+        state->s = frame->message;
+        free(frame);
+    }
+    """
+    void cypari2_sig_error_current_thread(void *state) noexcept nogil
+    void *cypari2_callback_signal_push(void *state) noexcept nogil
+    void cypari2_callback_signal_pop(void *state, void *saved) noexcept nogil
+    int cypari2_install_signal_router(void *state) noexcept nogil
+    void cypari2_set_signal_owner_active(int active) noexcept nogil
+    int cypari2_is_signal_owner() noexcept nogil
+
+
+cdef inline void sig_error_local() noexcept nogil:
+    """Jump to this thread's active ``sig_on`` without a process signal."""
+    cypari2_sig_error_current_thread(<void *>&cysigs)
+
+
+cdef inline void *callback_signal_push() except NULL:
+    """Allow PARI calls in a Python callback to use a nested jump target."""
+    cdef void *saved = cypari2_callback_signal_push(<void *>&cysigs)
+    if saved is NULL:
+        raise MemoryError
+    return saved
+
+
+cdef inline void callback_signal_pop(void *saved) noexcept:
+    """Restore the PARI caller's cysignals jump target."""
+    cypari2_callback_signal_pop(<void *>&cysigs, saved)
+
+
+cdef inline int install_signal_router() except -1:
+    """Route asynchronous cysignals interrupts to the PARI owner."""
+    if cypari2_install_signal_router(<void *>&cysigs) < 0:
+        raise OSError("failed to install cypari2 signal router")
+    return 0
+
+
+cdef inline void set_signal_owner_active(bint active) noexcept:
+    cypari2_set_signal_owner_active(active)
+
+
+cdef inline bint is_signal_owner() noexcept nogil:
+    return cypari2_is_signal_owner()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to CyPari2's documentation!
    :caption: Contents:
 
    pari_instance
+   threading
    gen
    stack
    closure

--- a/docs/source/threading.rst
+++ b/docs/source/threading.rst
@@ -1,0 +1,63 @@
+Threading model
+===============
+
+The Python API can be called from arbitrary Python threads.  CyPari2 sends
+every operation which touches libpari to one long-lived owner thread.  This
+includes construction of :class:`~cypari2.gen.Gen` objects, methods on
+:class:`~cypari2.pari_instance.Pari` and :class:`~cypari2.gen.Gen`, conversion,
+error recovery, and destruction of cloned ``GEN`` values.  Calls from several
+Python threads are therefore safe but are serialized.
+
+A ``Gen`` returned on one Python thread may be retained, used, and destroyed
+on another thread.  Before a result leaves the owner, CyPari2 moves every
+contained ``Gen`` from the PARI stack to the owner context's clone heap.
+The same cleanup runs after exceptions and covers ``Gen`` objects retained by
+side effects in Python conversion hooks or callbacks.
+
+PARI also provides ``pari_thread_start`` and a private stack for each native
+thread.  That model requires a parent to copy a result out of the child stack
+before freeing it.  It does not by itself fit a Python ``Gen``, whose lifetime,
+aliases, and eventual destruction thread are arbitrary.  Keeping one
+long-lived owner gives every wrapped ``GEN`` one stable allocation and clone
+registry instead of attempting to migrate an object graph between transient
+caller stacks.
+
+PARI's own internal pthread parallelism remains available.  For example, a
+parallel PARI operation using a native GP closure can still use the configured
+``nbthreads`` value.  A Python callable cannot execute inside a PARI worker,
+because those workers do not own the Python GIL.  Such an attempt raises a
+``PariError`` instead of entering Python from the foreign thread.  Set
+``nbthreads`` to 1 when a PARI parallel API must invoke a Python callable::
+
+    pari.default("nbthreads", 1)
+    pari.parapply(lambda value: value + 1, range(4))
+
+Python callbacks which run on the owner may call CyPari2 again.  Successful
+results and uncaught nested PARI exceptions are propagated normally.  PARI
+resets its evaluator when reporting an error, so a callback cannot catch a
+nested :class:`~cypari2.handle_error.PariError` and continue its enclosing PARI
+evaluation.  CyPari2 detects that case and aborts the outer evaluation with a
+:class:`RuntimeError` instead of returning into the reset evaluator.
+The callback runs with the owner thread's Python thread-local and
+:mod:`contextvars` state, not the submitting thread's state.  It must not
+synchronously wait for another thread to finish a CyPari2 call, since that
+call is queued behind the callback itself; make a nested CyPari2 call directly
+in the callback instead.  Output emitted by a native PARI worker is written
+directly to the process's C ``stdout``; redirecting :data:`sys.stdout` only
+affects output emitted on the owner.  Other owner-only hooks, including stack
+resizing and IPython plotting, raise ``PariError`` when invoked by a native
+PARI worker.  On POSIX, asynchronous cysignals interrupts such as ``SIGINT``
+and ``SIGALRM`` are routed to the owner while it is inside a request, then
+re-raised in the calling Python thread.
+
+Forking a process after CyPari2 has initialized libpari cannot preserve the
+vanished owner thread or its PARI context.  A child in that state raises
+``RuntimeError`` on use.  With :mod:`multiprocessing`, use the ``spawn`` start
+method, or fork before the first CyPari2 operation, including module-level
+conversion helpers.
+
+This guarantee covers the public Python API, including direct unbound method
+calls on the extension types.  Cython code which ``cimport``s CyPari2's
+``.pxd`` files and dereferences a raw ``GEN`` bypasses Python dispatch; such
+code must arrange to run in the owner context and must not transfer raw stack
+pointers between threads.

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ py = import('python').find_installation(pure: false)
 # Compilers
 cc = meson.get_compiler('c')
 cython = meson.get_compiler('cython')
+threads = dependency('threads')
 # Workaround as described in https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#arithmetic-methods
 add_project_arguments('-X c_api_binop_methods=True', language: 'cython')
 # Compiler debug output

--- a/tests/test.pyx
+++ b/tests/test.pyx
@@ -2,11 +2,18 @@
 # to compute zeta(2) and factor a polynomial over a finite field, as in the README.
 
 from cypari2.paridecl cimport pari_printf, pari_init, pari_close, DEFAULTPREC, szeta, stoi, pol_x, gpow, gadd, factorff, lift, centerlift, setvarn, gen_2, gen_m1, gen_0, INIT_DFTm, pari_init_opts, pari_mainstack
+from cypari2.paridecl cimport paricfg_mt_engine
 from cypari2.types cimport GEN
 from cypari2.closure cimport _pari_init_closure
 from cypari2.stack cimport (new_gen, new_gen_noclear, clear_stack,
                      set_pari_stack_size, before_resize, after_resize)
 from libc.stdio cimport printf
+
+
+def pari_mt_engine():
+    """Return the threading engine selected when PARI was built."""
+    return paricfg_mt_engine.decode("ascii")
+
 
 def main():
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python
+
+import gc
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+
+import cypari2
+from cypari2.convert import gen_to_python, integer_to_gen
+
+
+class TestThreadSafety(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pari = cypari2.Pari()
+
+    def test_original_issue_without_executor_initializer(self):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(self.pari.issquarefree, 15)
+            self.assertEqual(future.result(timeout=10), 1)
+
+    def test_gen_survives_creating_thread(self):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            value = executor.submit(self.pari, "[1, 2, 3]").result(timeout=10)
+
+        self.assertEqual(repr(value), "[1, 2, 3]")
+        self.assertEqual([int(entry) for entry in value], [1, 2, 3])
+        value[1] = 9
+        self.assertEqual(repr(value), "[1, 9, 3]")
+
+    def test_same_gen_from_many_threads(self):
+        value = self.pari("[1, 2, 3, 4]")
+
+        def inspect_value(index):
+            return int(value[index]), repr(value + value)
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(inspect_value, i % 4) for i in range(200)]
+            results = [future.result(timeout=10) for future in futures]
+
+        self.assertEqual(results[0], (1, "[2, 4, 6, 8]"))
+        self.assertEqual(results[-1], (4, "[2, 4, 6, 8]"))
+
+    def test_same_gen_can_be_mutated_from_many_threads(self):
+        value = self.pari.vector(100)
+
+        def set_entry(index):
+            value[index] = index + 1
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(set_entry, range(100)))
+        self.assertEqual([int(entry) for entry in value], list(range(1, 101)))
+
+    def test_gen_iterator_is_lazy_and_thread_safe(self):
+        value = self.pari([1, 2, 3])
+        iterator = iter(value)
+        value[0] = 9
+        self.assertEqual(next(iterator), 9)
+        self.assertEqual([int(entry) for entry in iterator], [2, 3])
+        self.assertIsNot(next(iter(value)), next(iter(value)))
+        with self.assertRaises(StopIteration):
+            next(iterator)
+        with self.assertRaises(TypeError):
+            iter(self.pari(42))
+
+        iterator = iter(self.pari(range(40)))
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            entries = list(executor.map(lambda _: next(iterator), range(40)))
+        self.assertEqual(sorted(map(int, entries)), list(range(40)))
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+    def test_owner_callback_iterator_can_escape_safely(self):
+        saved = []
+
+        def save_iterator():
+            # Polynomial iteration creates a temporary coefficient vector on
+            # the PARI stack; the proxy must survive stabilization of it.
+            saved.append(iter(self.pari("1 + 2*x + 3*x^2")))
+            return 0
+
+        self.assertEqual(self.pari(save_iterator)(), 0)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            entries = executor.submit(list, saved.pop()).result(timeout=10)
+        self.assertEqual(list(map(int, entries)), [1, 2, 3])
+
+    def test_pari_subclass_helpers_stay_on_calling_thread(self):
+        class PariSubclass(cypari2.Pari):
+            def current_thread(self):
+                return threading.get_ident()
+
+        pari = PariSubclass()
+        self.assertEqual(pari.current_thread(), threading.get_ident())
+
+        def identify_thread():
+            return threading.get_ident(), pari.current_thread()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            caller, observed = executor.submit(identify_thread).result(timeout=10)
+        self.assertEqual(observed, caller)
+        self.assertEqual(pari.issquarefree(15), 1)
+
+    def test_results_can_be_destroyed_on_worker_threads(self):
+        def create_and_destroy(n):
+            value = self.pari(n).nextprime()
+            text = repr(value)
+            del value
+            gc.collect()
+            return text
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(create_and_destroy, range(1, 201)))
+
+        self.assertEqual(results[0], "2")
+        self.assertTrue(results[-1])
+        # Submit one more operation so all previously queued clone releases
+        # have run on the PARI owner thread.
+        self.assertEqual(self.pari(1), 1)
+
+    def test_clone_release_can_reenter_enqueue_lock(self):
+        code = r'''
+import gc
+
+from cypari2 import Pari
+from cypari2._thread_runtime import runtime
+
+pari = Pari()
+value = pari(123)
+# Advance the owner loop so that its local request no longer retains value.
+pari(0)
+with runtime._queue_lock:
+    del value
+    gc.collect()
+print(pari(42))
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            completed = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=directory,
+                env=os.environ.copy(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), "42")
+
+    def test_clone_heap_is_reclaimed_after_worker_use(self):
+        from cypari2._thread_runtime import runtime
+
+        def drain_releases():
+            gc.collect()
+            runtime.call(lambda: None)
+            gc.collect()
+            runtime.call(lambda: None)
+
+        def heap_usage():
+            usage = tuple(self.pari.getheap().python())
+            drain_releases()
+            return usage
+
+        def create_and_destroy(n):
+            return int(self.pari(n).nextprime() + 1)
+
+        drain_releases()
+        baseline = heap_usage()
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(create_and_destroy, range(1, 1001)))
+        self.assertEqual(heap_usage(), baseline)
+
+    def test_exceptions_cross_thread_boundary(self):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(self.pari, "1/0")
+            with self.assertRaises(cypari2.PariError):
+                future.result(timeout=10)
+
+    def test_python_callback_is_reentrant_on_owner(self):
+        closure = self.pari(lambda value: value + 1)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(closure, 41).result(timeout=10)
+        self.assertEqual(result, 42)
+
+    def test_method_captured_on_owner_remains_safe(self):
+        captured = []
+        value = self.pari(17)
+
+        def capture_methods():
+            captured.extend([self.pari.issquarefree, value.nextprime])
+
+        self.pari(capture_methods)()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            squarefree = executor.submit(captured[0], 15).result(timeout=10)
+            next_prime = executor.submit(captured[1]).result(timeout=10)
+        self.assertEqual(squarefree, 1)
+        self.assertEqual(next_prime, 17)
+
+    def test_unbound_extension_methods_dispatch_to_owner(self):
+        value = self.pari(16)
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            squarefree = executor.submit(
+                type(self.pari).issquarefree, self.pari, 15)
+            square_root = executor.submit(type(value).sqrt, value)
+            next_prime = executor.submit(type(value).nextprime, value)
+            self.assertEqual(squarefree.result(timeout=10), 1)
+            self.assertEqual(square_root.result(timeout=10), 4)
+            self.assertEqual(next_prime.result(timeout=10), 17)
+
+    def test_nested_pari_error_in_python_callback_is_safe(self):
+        multiply = self.pari(lambda left, right: left * right)
+        with self.assertRaises(cypari2.PariError):
+            multiply([1], [2])
+
+        # The nested error must not longjmp across the callback's Python
+        # frames and corrupt the owner thread.
+        self.assertEqual(self.pari(41) + 1, 42)
+
+        def catch_nested_error():
+            try:
+                self.pari("1/0")
+            except cypari2.PariError:
+                return self.pari(42)
+
+        with self.assertRaisesRegex(RuntimeError, "cannot be caught"):
+            self.pari(catch_nested_error)()
+        self.assertEqual(self.pari(42), 42)
+
+        class CallbackResult:
+            def __str__(inner_self):
+                try:
+                    self.pari("1/0")
+                except cypari2.PariError:
+                    return "42"
+
+        with self.assertRaisesRegex(RuntimeError, "cannot be caught"):
+            self.pari(lambda: CallbackResult())()
+        self.assertEqual(self.pari(42), 42)
+
+        # PARI's own iferr recovery is contained inside the nested call and
+        # must not be confused with a PariError suppressed by Python.
+        self.assertEqual(
+            self.pari(lambda: self.pari("iferr(1/0, E, 42)"))(),
+            42,
+        )
+
+    def test_python_callback_side_effect_gen_is_stabilized(self):
+        saved = []
+
+        def save_value():
+            saved.append(self.pari(123456789))
+            return 0
+
+        self.assertEqual(self.pari(save_value)(), 0)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(lambda: saved.pop() + 1).result(timeout=10)
+        self.assertEqual(result, 123456790)
+
+    def test_python_callback_exception_stabilizes_side_effect_gen(self):
+        saved = []
+
+        def save_then_raise():
+            saved.append(self.pari(41))
+            raise ValueError("callback failed")
+
+        with self.assertRaisesRegex(ValueError, "callback failed"):
+            self.pari(save_then_raise)()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(lambda: saved.pop() + 1).result(timeout=10)
+        self.assertEqual(result, 42)
+
+    def test_stack_gen_can_be_destroyed_on_worker_during_callback(self):
+        saved = []
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            def create_and_release_elsewhere():
+                saved.extend(self.pari(123456789 + i) for i in range(64))
+
+                def release():
+                    saved.clear()
+                    gc.collect()
+
+                executor.submit(release).result(timeout=10)
+                return 0
+
+            self.assertEqual(self.pari(create_and_release_elsewhere)(), 0)
+
+        self.assertEqual(self.pari(41) + 1, 42)
+
+    def test_python_conversion_side_effect_gen_is_stabilized(self):
+        saved = []
+        old_level = self.pari.get_debug_level()
+
+        class DebugLevel:
+            def __int__(inner_self):
+                saved.append(self.pari(72))
+                return old_level
+
+        self.pari.set_debug_level(DebugLevel())
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(lambda: saved.pop() + 1).result(timeout=10)
+        self.assertEqual(result, 73)
+
+        class FailingDebugLevel:
+            def __int__(inner_self):
+                saved.append(self.pari(99))
+                raise ValueError("conversion failed")
+
+        with self.assertRaisesRegex(ValueError, "conversion failed"):
+            self.pari.set_debug_level(FailingDebugLevel())
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(lambda: saved.pop() + 1).result(timeout=10)
+        self.assertEqual(result, 100)
+
+    def test_python_callback_in_pari_worker_fails_safely(self):
+        old_threads = int(self.pari.default("nbthreads"))
+        try:
+            self.pari.default("nbthreads", 2)
+            if int(self.pari.default("nbthreads")) < 2:
+                self.skipTest("PARI was built without pthread workers")
+
+            with self.assertRaisesRegex(
+                    cypari2.PariError, "set nbthreads to 1"):
+                self.pari.parapply(lambda value: value + 1, range(4))
+
+            # Native PARI closures retain PARI's internal parallelism.
+            native = self.pari("value -> value + 1")
+            self.assertEqual(
+                list(self.pari.parapply(native, range(4))),
+                [1, 2, 3, 4],
+            )
+
+            self.pari.default("nbthreads", 1)
+            self.assertEqual(
+                list(self.pari.parapply(lambda value: value + 1, range(4))),
+                [1, 2, 3, 4],
+            )
+        finally:
+            self.pari.default("nbthreads", old_threads)
+
+    def test_stack_resize_callback_in_pari_worker_fails_safely(self):
+        old_threads = int(self.pari.default("nbthreads"))
+        try:
+            self.pari.default("nbthreads", 2)
+            if int(self.pari.default("nbthreads")) < 2:
+                self.skipTest("PARI was built without pthread workers")
+
+            for setting in ("parisize", "parisizemax"):
+                expression = (
+                    f"parapply(x -> default({setting}), [1, 2, 3, 4])"
+                )
+                with self.assertRaisesRegex(
+                        cypari2.PariError, "cannot run in a PARI worker"):
+                    self.pari(expression)
+                self.assertEqual(self.pari(42), 42)
+        finally:
+            self.pari.default("nbthreads", old_threads)
+
+    @unittest.skipIf(os.name == "nt", "PARI pthread test")
+    def test_pari_worker_output_does_not_enter_python(self):
+        code = r'''
+from cypari2 import Pari
+pari = Pari()
+pari.default("nbthreads", 2)
+pari("parapply(value -> print(value), [1, 2, 3, 4])")
+print("owner still usable", pari(1))
+'''
+        environment = os.environ.copy()
+        with tempfile.TemporaryDirectory() as directory:
+            completed = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=directory,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("owner still usable 1", completed.stdout)
+
+    @unittest.skipUnless(hasattr(signal, "SIGALRM"), "requires SIGALRM")
+    def test_alarm_is_routed_to_owner(self):
+        from cysignals.alarm import AlarmInterrupt, alarm, cancel_alarm
+
+        try:
+            alarm(0.05)
+            with self.assertRaises(AlarmInterrupt):
+                self.pari("while(1,)")
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                alarm(0.05)
+                future = executor.submit(self.pari, "while(1,)")
+                with self.assertRaises(AlarmInterrupt):
+                    future.result(timeout=10)
+
+            # A re-entrant PARI call made by a Python callback has its own
+            # cysignals frame and must not inherit the outer callback's
+            # interrupt block indefinitely.
+            alarm(0.05)
+            with self.assertRaises(AlarmInterrupt):
+                self.pari(lambda: self.pari("while(1,)"))()
+        finally:
+            cancel_alarm()
+        self.assertEqual(self.pari(1), 1)
+
+    def test_public_conversion_helpers(self):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            value = executor.submit(integer_to_gen, 2**100).result(timeout=10)
+            converted = executor.submit(gen_to_python, value).result(timeout=10)
+        self.assertEqual(converted, 2**100)
+
+    def test_module_helpers_initialize_owner(self):
+        code = r'''
+from cypari2.closure import objtoclosure
+from cypari2.convert import integer_to_gen
+from cypari2.gen import objtogen
+print(integer_to_gen(5), objtogen(6), objtoclosure(lambda: 7)())
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            completed = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=directory,
+                env=os.environ.copy(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), "5 6 7")
+
+    @unittest.skipUnless(hasattr(os, "fork"), "requires os.fork")
+    def test_fork_after_initialization_fails_safely(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"This process .* is multi-threaded",
+                category=DeprecationWarning,
+            )
+            child = os.fork()
+        if child == 0:
+            try:
+                try:
+                    self.pari(1)
+                except RuntimeError as exc:
+                    os._exit(0 if "spawn" in str(exc) else 2)
+                os._exit(3)
+            except BaseException:
+                os._exit(4)
+
+        _, status = os.waitpid(child, 0)
+        self.assertTrue(os.WIFEXITED(status))
+        self.assertEqual(os.WEXITSTATUS(status), 0)
+        self.assertEqual(self.pari(1), 1)
+
+    def test_concurrent_pari_construction(self):
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(cypari2.Pari) for _ in range(32)]
+            instances = [future.result(timeout=10) for future in futures]
+        self.assertTrue(all(instance.issquarefree(15) == 1 for instance in instances))
+        self.assertTrue(all(instance.PARI_ZERO == 0 for instance in instances))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import contextvars
 import gc
 import os
 import signal
@@ -9,16 +10,23 @@ import tempfile
 import threading
 import unittest
 import warnings
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 
 import cypari2
 from cypari2.convert import gen_to_python, integer_to_gen
+from cypari2.test import pari_mt_engine
 
 
 class TestThreadSafety(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.pari = cypari2.Pari()
+
+    def require_pari_pthread_workers(self):
+        engine = pari_mt_engine()
+        if engine != "pthread":
+            self.skipTest(f"requires PARI pthread engine, found {engine!r}")
 
     def test_original_issue_without_executor_initializer(self):
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -132,7 +140,7 @@ from cypari2._thread_runtime import runtime
 
 pari = Pari()
 value = pari(123)
-# Advance the owner loop so that its local request no longer retains value.
+# Ensure that owner-side bookkeeping for the result has completed.
 pari(0)
 with runtime._queue_lock:
     del value
@@ -180,6 +188,152 @@ print(pari(42))
             future = executor.submit(self.pari, "1/0")
             with self.assertRaises(cypari2.PariError):
                 future.result(timeout=10)
+
+    def test_context_variables_cross_thread_boundary(self):
+        from cypari2._thread_runtime import runtime
+
+        marker = contextvars.ContextVar("cypari2_test_marker")
+
+        def read_and_mutate():
+            value = marker.get()
+            marker.set(f"owner:{value}")
+            return value
+
+        def call_from_context(value):
+            token = marker.set(value)
+            try:
+                return runtime.call(read_and_mutate), marker.get()
+            finally:
+                marker.reset(token)
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(
+                call_from_context, (f"caller:{i}" for i in range(64))))
+
+        self.assertEqual(
+            results,
+            [(f"caller:{i}", f"caller:{i}") for i in range(64)],
+        )
+        self.assertEqual(
+            runtime.call(lambda: marker.get("unset")), "unset")
+
+        class Payload:
+            pass
+
+        payload = Payload()
+        payload_ref = weakref.ref(payload)
+        token = marker.set(payload)
+        try:
+            runtime.call(lambda: None)
+        finally:
+            marker.reset(token)
+        del payload
+        gc.collect()
+        self.assertIsNone(payload_ref())
+
+    def test_call_completes_after_request_context_exits(self):
+        from cypari2._thread_runtime import _PariThreadRuntime
+
+        request_finished = threading.Event()
+        release_context = threading.Event()
+
+        class PausingRuntime(_PariThreadRuntime):
+            def _run_request(inner_self, request):
+                super()._run_request(request)
+                request_finished.set()
+                release_context.wait()
+
+        runtime = PausingRuntime()
+        runtime.install_initializer(lambda: None)
+        try:
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(runtime.call, lambda: 42)
+                self.assertTrue(request_finished.wait(timeout=10))
+                try:
+                    self.assertFalse(future.done())
+                finally:
+                    release_context.set()
+                self.assertEqual(future.result(timeout=10), 42)
+        finally:
+            release_context.set()
+            runtime.shutdown()
+
+    @unittest.skipIf(
+        sys.version_info < (3, 14),
+        "context-aware warnings require Python 3.14",
+    )
+    def test_context_aware_warnings_cross_thread_boundary(self):
+        code = r'''
+import sys
+import warnings
+
+from cypari2 import Pari
+
+assert sys.flags.context_aware_warnings
+pari = Pari()
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    pari("[2,1;2,1]").matkerint(1)
+assert len(caught) == 1, caught
+assert issubclass(caught[0].category, DeprecationWarning)
+'''
+        completed = subprocess.run(
+            [sys.executable, "-X", "context_aware_warnings=1", "-c", code],
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    @unittest.skipIf(
+        sys.version_info < (3, 14),
+        "explicit thread contexts require Python 3.14",
+    )
+    def test_owner_thread_does_not_retain_creator_context(self):
+        code = r'''
+import contextvars
+import gc
+import sys
+import weakref
+
+from cypari2._thread_runtime import _PariThreadRuntime
+
+assert sys.flags.thread_inherit_context
+runtime = _PariThreadRuntime()
+runtime.install_initializer(lambda: None)
+
+class Payload:
+    pass
+
+marker = contextvars.ContextVar("cypari2_test_creator_marker")
+payload = Payload()
+payload_ref = weakref.ref(payload)
+token = marker.set(payload)
+runtime.call(lambda: None)
+marker.reset(token)
+del payload
+
+# Advance the owner loop so neither its local request nor its per-request
+# context can retain the payload.  Its Thread bootstrap context must not do so.
+runtime.call(lambda: None)
+for _ in range(3):
+    gc.collect()
+assert payload_ref() is None, payload_ref()
+runtime.shutdown()
+'''
+        completed = subprocess.run(
+            [sys.executable, "-X", "thread_inherit_context=1", "-c", code],
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
 
     def test_python_callback_is_reentrant_on_owner(self):
         closure = self.pari(lambda value: value + 1)
@@ -318,11 +472,10 @@ print(pari(42))
         self.assertEqual(result, 100)
 
     def test_python_callback_in_pari_worker_fails_safely(self):
+        self.require_pari_pthread_workers()
         old_threads = int(self.pari.default("nbthreads"))
         try:
             self.pari.default("nbthreads", 2)
-            if int(self.pari.default("nbthreads")) < 2:
-                self.skipTest("PARI was built without pthread workers")
 
             with self.assertRaisesRegex(
                     cypari2.PariError, "set nbthreads to 1"):
@@ -344,11 +497,10 @@ print(pari(42))
             self.pari.default("nbthreads", old_threads)
 
     def test_stack_resize_callback_in_pari_worker_fails_safely(self):
+        self.require_pari_pthread_workers()
         old_threads = int(self.pari.default("nbthreads"))
         try:
             self.pari.default("nbthreads", 2)
-            if int(self.pari.default("nbthreads")) < 2:
-                self.skipTest("PARI was built without pthread workers")
 
             for setting in ("parisize", "parisizemax"):
                 expression = (
@@ -361,8 +513,8 @@ print(pari(42))
         finally:
             self.pari.default("nbthreads", old_threads)
 
-    @unittest.skipIf(os.name == "nt", "PARI pthread test")
     def test_pari_worker_output_does_not_enter_python(self):
+        self.require_pari_pthread_workers()
         code = r'''
 from cypari2 import Pari
 pari = Pari()


### PR DESCRIPTION
## Summary

- route every Python-visible libpari operation through one long-lived owner thread
- stabilize `Gen` lifetimes at request boundaries and return clone destruction to the owner context
- make Python callbacks, nested PARI errors, signals, iteration, and native PARI worker hooks safe across thread boundaries
- propagate each caller's Python `Context` into its owner request without retaining it after completion
- build CI's bundled PARI with the pthread engine and verify that Configure did not silently fall back to `single`
- add the regression suite to `make check` while leaving cibuildwheel's `pyproject.toml` test command doctest-only

## Motivation and design

PARI's thread-local mode gives each initialized native thread a private stack and clone registry. The crash in #107 occurs because an ordinary Python thread-pool worker enters libpari without owning such a context.

Initializing every transient Python worker is not sufficient for CyPari2: a `Gen` can be aliased, returned to another thread, retained by a callback, and eventually destroyed on an unrelated thread. A per-caller stack would therefore require migrating an arbitrary object graph before every worker exits.

This PR instead gives all wrapped `GEN` values one permanent owner context. Calls from arbitrary Python threads are marshalled to that thread and serialized. Before a request returns, every live stack-backed `Gen` is moved to the owner's clone heap; clone releases are queued back to that same owner. PARI's own pthread engine remains available for native PARI closures.

Python execution context is part of the request boundary as well. Each synchronous request runs under a snapshot of its caller's `contextvars.Context`, which preserves context-aware warning capture on Python 3.14/free-threaded builds. The long-lived owner starts with an explicitly empty context, and completion is published only after the per-request context has been exited and released.

The implementation also:

- preserves lazy `Gen` iteration while confining each `next()` operation to the owner
- supports re-entrant CyPari2 calls from Python callbacks without long-jumping across Python frames
- rejects Python callbacks from PARI's native worker threads while retaining native-closure parallelism
- routes asynchronous POSIX interrupts to the active owner request
- keeps worker output and plotting hooks from entering Python without the GIL
- fails safely after a process forks with an initialized owner and documents `spawn` as the supported multiprocessing model
- keeps user-defined `Pari` subclass helpers on their calling Python thread
- detects PARI's actual build-time threading engine so worker-only tests skip only on legitimate single-engine builds

The guarantee covers the public Python API, including unbound extension methods. Cython callers that directly dereference raw `GEN` values through the `.pxd` interface still need to arrange their own owner-context discipline.

## Testing

- Python 3.12 with PARI 2.17.3/pthread, `make check`:
  - 2479 doctests, 0 failures
  - 3 integer compatibility tests
  - 3 backward compatibility tests
  - 31 threading tests, 2 Python-3.14-only tests skipped
- Python 3.14 with PARI 2.17.3/pthread:
  - 31 threading tests, all passed
  - 2479 doctests with both `context_aware_warnings=1` and `thread_inherit_context=1`, 0 failures
- Python 3.14 with PARI 2.17.3/single:
  - 31 threading tests passed, with exactly 3 pthread-worker-only tests skipped
- PARI 2.15.5 Configure probe selects `pthread`; the new post-Configure assertion rejects a `single` build
- `bash -n .install-pari.sh`, Python syntax compilation, and `git diff --check`
- GitHub Actions after the fix:
  - all 12 main CI jobs passed (9 Ubuntu combinations and 3 macOS combinations)
  - sdist, Linux x86_64 wheels, Linux arm64 wheels, and macOS Intel wheels passed
  - both manylinux and musllinux cp314t wheel doctests passed with 0 failures

The remaining `macos-latest` arm64 wheel failure is independent of this change: current Homebrew PARI/GMP bottles require macOS 26 while the wheel targets macOS 15. PR #211 pins that job to macOS 15 and has a fully green wheel matrix.

Closes #107
